### PR TITLE
Preserve mixed-bundle proposals across editor retries

### DIFF
--- a/agents/__tests__/editor.test.ts
+++ b/agents/__tests__/editor.test.ts
@@ -7242,6 +7242,114 @@ describe('editor agent', () => {
       expect(JSON.stringify(applyCall.input)).not.toContain('oldString":"stale')
     })
 
+    test('keeps a mixed-bundle proposal whose retries never produce a clean result', () => {
+      // Regression: a proposal that returns a mixed (success + hard failure)
+      // bundle on every attempt was previously discarded entirely, so the run
+      // reported "no usable proposal" even though a real diff had streamed.
+      // It must now retry (to try for a clean result) but still keep the good
+      // diff and reach the selector instead of erroring out.
+      const multiPromptEditor = createMultiPromptEditor()
+      const mockAgentState = createMockAgentState([
+        { role: 'user', content: [{ type: 'text', text: 'Original task' }] },
+      ])
+      const generator = multiPromptEditor.handleSteps!({
+        agentState: mockAgentState,
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        } as any,
+        params: { prompts: ['minimal'] },
+      })
+
+      const mixedBundleResult: any[] = [
+        {
+          type: 'json',
+          value: [
+            {
+              value: {
+                toolCalls: [
+                  {
+                    toolName: 'propose_str_replace',
+                    input: {
+                      path: 'src/a.ts',
+                      replacements: [{ oldString: 'old', newString: 'new' }],
+                    },
+                  },
+                  {
+                    toolName: 'propose_str_replace',
+                    input: {
+                      path: 'src/missing.ts',
+                      replacements: [{ oldString: 'gone', newString: 'new' }],
+                    },
+                  },
+                ],
+                toolResults: [
+                  { file: 'src/a.ts', unifiedDiff: '@@ diff A' },
+                  {
+                    file: 'src/missing.ts',
+                    errorMessage: 'The file does not exist.',
+                  },
+                ],
+                unifiedDiffs: '--- src/a.ts ---\n@@ diff A',
+              },
+            },
+          ],
+        },
+      ]
+
+      expect(
+        (generator.next().value as ToolCall<'set_messages'>).toolName,
+      ).toBe('set_messages')
+
+      // First proposal spawn.
+      expect(
+        generator.next({
+          agentState: mockAgentState,
+          toolResult: [],
+          stepsComplete: false,
+        }).value as ToolCall<'spawn_agents'>,
+      ).toMatchObject({ toolName: 'spawn_agents' })
+
+      // Attempt 0 returns mixed → retry (attempt 1).
+      expect(
+        generator.next({
+          agentState: mockAgentState,
+          toolResult: mixedBundleResult,
+          stepsComplete: false,
+        }).value as ToolCall<'spawn_agents'>,
+      ).toMatchObject({
+        input: { agents: [{ agent_type: 'editor-implementor-proposal-1' }] },
+      })
+
+      // Attempt 1 returns mixed → retry (attempt 2).
+      expect(
+        generator.next({
+          agentState: mockAgentState,
+          toolResult: mixedBundleResult,
+          stepsComplete: false,
+        }).value as ToolCall<'spawn_agents'>,
+      ).toMatchObject({
+        input: { agents: [{ agent_type: 'editor-implementor-proposal-1' }] },
+      })
+
+      // Attempt 2 (final) returns mixed. Retries are exhausted, but the good
+      // diff must be preserved and the run must advance to the selector rather
+      // than yielding a "no usable proposal" error.
+      const afterProposals = generator.next({
+        agentState: mockAgentState,
+        toolResult: mixedBundleResult,
+        stepsComplete: false,
+      }).value as ToolCall<'spawn_agents' | 'set_output'>
+
+      expect(afterProposals.toolName).not.toBe('set_output')
+      expect(afterProposals).toMatchObject({
+        toolName: 'spawn_agents',
+        input: { agents: [{ agent_type: 'best-of-n-selector2' }] },
+      })
+    })
+
     test('selector succeeds on retry after first attempt fails', () => {
       const multiPromptEditor = createMultiPromptEditor()
       const mockAgentState = createMockAgentState([

--- a/agents/editor/best-of-n/editor-multi-prompt.ts
+++ b/agents/editor/best-of-n/editor-multi-prompt.ts
@@ -233,6 +233,10 @@ function* handleStepsMultiPrompt({
       proposalAgentTypes[index] ??
       proposalAgentTypes[proposalAgentTypes.length - 1]
     let lastResult: ProposalResult | ProposalFailure | undefined
+    // Keep the best attempt across retries, not merely the last one. A good
+    // (possibly mixed) bundle from an early attempt must never be lost to a
+    // worse/empty later attempt.
+    let bestResult: ProposalResult | ProposalFailure | undefined
     let forceDirectRetry = false
 
     for (let attempt = 0; attempt < maxProposalAttempts; attempt++) {
@@ -287,6 +291,33 @@ function* handleStepsMultiPrompt({
         implementorResults,
       )[0]
 
+      // Track the best attempt across retries so a good (possibly mixed)
+      // bundle from an early attempt is never lost when a later retry comes
+      // back worse or empty. This is what makes retrying non-destructive.
+      if (isBetterProposalAttempt(lastResult, bestResult)) {
+        bestResult = lastResult
+      }
+
+      // [v0] temporary diagnostic - remove once the proposal stage is confirmed.
+      console.log('[v0] proposal attempt', {
+        index,
+        attempt,
+        agentType: currentAgentType,
+        successfulDiffCount: getSuccessfulLedgerDiffResults(lastResult).length,
+        failedCount: getUsableProposalToolResultsFromResult(lastResult).filter(
+          isFailedEditResult,
+        ).length,
+        toolCallCount: getUsableProposalToolCalls(lastResult).length,
+        stopReason: isObject(lastResult)
+          ? (lastResult as ProposalResult).stopReason
+          : undefined,
+        errorMessage: summarizeProposalFailure(lastResult),
+      })
+
+      // A clean, fully-usable proposal is good enough to stop early. Mixed
+      // (success + failure) bundles intentionally keep retrying to try for a
+      // cleaner result, but bestResult above guarantees the good diffs survive
+      // even if no clean attempt ever materializes.
       if (isUsableProposal(lastResult)) {
         break
       }
@@ -296,21 +327,43 @@ function* handleStepsMultiPrompt({
       }
     }
 
+    // Preserve any proposal that produced real ledger diffs - including mixed
+    // success+failure bundles. Gating this push on the strict isUsableProposal
+    // (which rejects ANY bundle containing a failed edit) was discarding good
+    // diffs that had already streamed in the UI, leaving the proposal looking
+    // like it "completed with no changes." Use the same criterion the
+    // downstream apply-verify-repair pipeline uses: at least one successful
+    // ledger diff. Truly empty proposals still fall through to the error branch.
+    const resultForPush = bestResult ?? lastResult
+    const pushedProposalResult = isObject(resultForPush)
+      ? (resultForPush as ProposalResult)
+      : undefined
+    const hasUsableDiffs =
+      getSuccessfulLedgerDiffResults(resultForPush).length > 0
+
+    // [v0] temporary diagnostic - remove once the proposal stage is confirmed.
+    console.log('[v0] proposal push decision', {
+      index,
+      branch: hasUsableDiffs ? 'rich' : 'empty',
+      successfulDiffCount: getSuccessfulLedgerDiffResults(resultForPush).length,
+      toolCallCount: getUsableProposalToolCalls(resultForPush).length,
+    })
+
     spawnedImplementations.push(
-      isUsableProposal(lastResult)
+      hasUsableDiffs
         ? {
-            toolCalls: getUsableProposalToolCalls(lastResult),
-            toolResults: getUsableProposalToolResultsFromResult(lastResult),
-            unifiedDiffs: buildLedgerUnifiedDiffs(lastResult),
-            stopReason: lastResult.stopReason,
-            proposalProgress: lastResult.proposalProgress,
-            proposalBudget: lastResult.proposalBudget,
+            toolCalls: getUsableProposalToolCalls(resultForPush),
+            toolResults: getUsableProposalToolResultsFromResult(resultForPush),
+            unifiedDiffs: buildLedgerUnifiedDiffs(resultForPush),
+            stopReason: pushedProposalResult?.stopReason,
+            proposalProgress: pushedProposalResult?.proposalProgress,
+            proposalBudget: pushedProposalResult?.proposalBudget,
           }
         : {
             toolCalls: [],
             toolResults: [],
             errorMessage:
-              summarizeProposalFailure(lastResult) ||
+              summarizeProposalFailure(resultForPush) ||
               'Proposal failed to return a usable implementation',
           },
     )
@@ -357,6 +410,18 @@ function* handleStepsMultiPrompt({
   const usableImplementations = rankImplementationsForSelection(
     implementations.filter(isUsableImplementation),
   )
+
+  // [v0] temporary diagnostic - remove once the proposal stage is confirmed.
+  console.log('[v0] proposal candidates', {
+    total: implementations.length,
+    usable: usableImplementations.length,
+    statuses: implementations.map((impl) => ({
+      id: impl.id,
+      usable: isUsableImplementation(impl),
+      successfulDiffCount: getSuccessfulLedgerDiffResults(impl).length,
+      stopReason: impl.stopReason,
+    })),
+  })
 
   if (usableImplementations.length === 0) {
     yield {
@@ -1354,6 +1419,50 @@ function* handleStepsMultiPrompt({
   ): boolean {
     const failure = summarizeProposalFailure(result).toLowerCase()
     return failure.includes('run cancelled by user')
+  }
+
+  /**
+   * Returns true when `candidate` is a strictly better proposal attempt than
+   * the current `incumbent`. Ranking is: (1) more successful ledger diffs wins,
+   * (2) on a tie, fewer failed edits wins, (3) still tied, a non-partial
+   * (cleanly completed) bundle wins over a partial one. This lets the retry
+   * loop keep the best work produced across attempts instead of blindly
+   * overwriting it with whatever the final attempt returned.
+   */
+  function isBetterProposalAttempt(
+    candidate: ProposalResult | ProposalFailure | undefined,
+    incumbent: ProposalResult | ProposalFailure | undefined,
+  ): boolean {
+    if (!isObject(candidate)) return false
+    if (!isObject(incumbent)) return true
+
+    const candidateDiffs = getSuccessfulLedgerDiffResults(candidate).length
+    const incumbentDiffs = getSuccessfulLedgerDiffResults(incumbent).length
+    if (candidateDiffs !== incumbentDiffs) {
+      return candidateDiffs > incumbentDiffs
+    }
+
+    const candidateFailures = getUsableProposalToolResultsFromResult(
+      candidate,
+    ).filter(isFailedEditResult).length
+    const incumbentFailures = getUsableProposalToolResultsFromResult(
+      incumbent,
+    ).filter(isFailedEditResult).length
+    if (candidateFailures !== incumbentFailures) {
+      return candidateFailures < incumbentFailures
+    }
+
+    const candidatePartial = isPartialStopReason(
+      (candidate as ProposalResult).stopReason,
+    )
+    const incumbentPartial = isPartialStopReason(
+      (incumbent as ProposalResult).stopReason,
+    )
+    if (candidatePartial !== incumbentPartial) {
+      return !candidatePartial
+    }
+
+    return false
   }
 
   function getProposalAttemptAgentType(params: {


### PR DESCRIPTION
- Ensured mixed-bundle proposals are preserved when retrying prompts within the editor's multi-prompt interface.
- Prevented the loss of existing proposal data during generation retries to improve workflow continuity.

[v0 Session](https://v0.app/chat/fh0qCwpM8Ey)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/1)
<!-- Reviewable:end -->
