### PR TITLE
Fix structured reviewer retry loop

### DIFF
--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -1692,7 +1692,7 @@ ${securityReviewSection}
           if (!reviewerFinalizationVerdict) {
             // Distinguish a reviewer CRASH (agent itself errored / produced no
             // output) from a reviewer that ran successfully but failed to
-            // begin its reply with LOOKS_GOOD/NON_BLOCKING/BLOCKING. The
+            // populate its required structured output. The
             // operator-facing message differs because the recovery action
             // differs: a crash means "retry or escalate; the verdict is
             // unknown" whereas a no-verdict means "re-prompt for the
@@ -1754,16 +1754,16 @@ ${securityReviewSection}
               }
             } else {
               activeWorkState.nextRequiredAction =
-                'Clarify or resolve the reviewer gate result; reviewer did not return LOOKS_GOOD or NON_BLOCKING.'
+                'Retry the automated reviewer gate; reviewer did not populate its required structured output.'
               markActiveWorkStateChanged()
               yield {
                 toolName: 'add_message',
                 input: {
                   role: 'user',
                   content: [
-                    `Reviewer gate: ${reviewerAgentType} ran but did not start with LOOKS_GOOD, NON_BLOCKING, or BLOCKING. Resolve or clarify before ending your turn:`,
+                    `Reviewer gate: ${reviewerAgentType} ran but returned no structured output. The verdict is unavailable.`,
                     '',
-                    'The reviewer must begin its reply with one of those labels (text mode) or emit a {"verdict": ...} JSON object. Re-spawn the reviewer with that contract reminder.',
+                    'Do not manually re-spawn the reviewer or ask it for a textual label. Continue the gate loop so the automated reviewer retries with its declared output schema; it must call set_output and populate verdict, findings, coverage, dimensions, requirementCoverage, snapshotFingerprint, and reviewedFiles.',
                   ].join('\n'),
                 },
                 includeToolCall: false,

--- a/agents/base2/gate-reviewer.ts
+++ b/agents/base2/gate-reviewer.ts
@@ -104,10 +104,10 @@ export function collectReviewerBlockers(toolResult: unknown): string[] {
 /**
  * Detects whether the reviewer agent itself crashed (returned an `errorMessage`
  * field, threw, or otherwise produced no usable output) as opposed to running
- * successfully but failing to emit a recognizable LOOKS_GOOD/NON_BLOCKING/
- * BLOCKING verdict. The two cases warrant very different operator messages:
+ * successfully but failing to populate its required structured verdict. The
+ * two cases warrant very different operator messages:
  *   - crash    → "reviewer agent crashed; verdict cannot be trusted" (retry or escalate)
- *   - no-verdict → "reviewer ran but didn't start with a verdict label" (re-prompt for format)
+ *   - no-verdict → "reviewer returned no structured output" (automated retry)
  *
  * Heuristic: walks the tool-result tree looking for any object that carries an
  * `errorMessage` string or whose `type === 'error'`. Returns the first such


### PR DESCRIPTION
## Summary
- stop injecting the obsolete text-label reviewer contract after null structured output
- keep reviewer recovery inside the automated structured-output gate
- update reviewer crash/no-output documentation

## Validation
- agents typecheck
- 95 base2/reviewer tests
- CLI typecheck
- regenerated 45 bundled agents
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/5)
<!-- Reviewable:end -->
