### PR TITLE
Fix structured agent tool availability

### DIFF
--- a/agents/__tests__/code-reviewer.test.ts
+++ b/agents/__tests__/code-reviewer.test.ts
@@ -16,7 +16,7 @@ describe('code-reviewer prompt isolation', () => {
     // Reviewers may read files (only) so they can always gather full final-file
     // context instead of reviewing from partial diff fragments. No mutating or
     // control tools are granted.
-    expect(reviewer.toolNames).toEqual(['read_files'])
+    expect(reviewer.toolNames).toEqual(['read_files', 'set_output'])
     expect(reviewer.spawnableAgents).toEqual([])
   })
 

--- a/agents/__tests__/specialists.test.ts
+++ b/agents/__tests__/specialists.test.ts
@@ -46,6 +46,7 @@ describe('specialist agents', () => {
       expect(agent.instructionsPrompt).toContain('snapshot_id')
       expect(agent.outputSchema).toBeDefined()
       expect(agent.outputMode).toBe('structured_output')
+      expect(agent.toolNames).toContain('set_output')
     }
   })
 

--- a/agents/reviewer/code-reviewer.ts
+++ b/agents/reviewer/code-reviewer.ts
@@ -26,7 +26,7 @@ export const createReviewer = (
   // deterministically reads the real files instead of guessing from partial
   // context. No mutating/control tools are granted, preserving the no-side-
   // effects review contract.
-  toolNames: ['read_files'],
+  toolNames: ['read_files', 'set_output'],
   spawnableAgents: [],
 
   // Reviewer agents intentionally do not inherit the parent system prompt. The

--- a/agents/security-reviewer/security-reviewer.ts
+++ b/agents/security-reviewer/security-reviewer.ts
@@ -50,7 +50,13 @@ const definition: SecretAgentDefinition = {
     required: ['schemaVersion', 'verdict', 'findings', 'coverage', 'dimensions'],
   },
   includeMessageHistory: false,
-  toolNames: ['read_files', 'read_outline', 'code_search', 'git_status'],
+  toolNames: [
+    'read_files',
+    'read_outline',
+    'code_search',
+    'git_status',
+    'set_output',
+  ],
   spawnableAgents: [],
 
   systemPrompt: `You are an adversarial security reviewer. You assume hostile inputs and look for exploitable weaknesses. You review against OWASP-style categories and the project's own threat surface. You report concrete, reproducible findings with severity, not generic hardening advice.`,

--- a/agents/specialists/create-specialist.ts
+++ b/agents/specialists/create-specialist.ts
@@ -83,6 +83,7 @@ export function createSpecialist(config: SpecialistConfig): SecretAgentDefinitio
         ? (['inspect_codebase_structure', 'inspect_feature_completeness'] as const)
         : []),
       ...(config.terminal ? (['run_terminal_command'] as const) : []),
+      'set_output',
     ],
     terminalPermissionProfile: config.terminal ? 'read-only' : undefined,
     spawnableAgents: [],

--- a/common/src/tools/__tests__/read-files-schema.test.ts
+++ b/common/src/tools/__tests__/read-files-schema.test.ts
@@ -80,4 +80,32 @@ describe('read_files input schema', () => {
       })
     }
   })
+
+  test('decodes provider-fragmented symbol selectors before inferring the path', () => {
+    const parsed = readFilesParams.inputSchema.safeParse({
+      paths: ['server/src/services/account.ts'],
+      symbols: [
+        '[{"names": ["setUserRole"',
+        '"changePlanForUser"',
+        '"listFeatureFlags"]}]',
+      ],
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data).toEqual({
+        paths: [],
+        symbols: [
+          {
+            path: 'server/src/services/account.ts',
+            names: [
+              'setUserRole',
+              'changePlanForUser',
+              'listFeatureFlags',
+            ],
+          },
+        ],
+      })
+    }
+  })
 })

--- a/common/src/tools/params/tool/read-files.ts
+++ b/common/src/tools/params/tool/read-files.ts
@@ -38,6 +38,22 @@ export const fileContentsSchema = z.union([
 
 const toolName = 'read_files'
 const endsAgentStep = true
+const decodeFragmentedSymbolSelectors = (input: unknown): unknown => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input
+  const record = input as Record<string, unknown>
+  if (!Array.isArray(record.symbols) || record.symbols.length === 0) return input
+  if (!record.symbols.every((value) => typeof value === 'string')) return input
+
+  const encoded = (record.symbols as string[]).join(',')
+  try {
+    const decoded = JSON.parse(encoded) as unknown
+    if (!Array.isArray(decoded)) return input
+    return { ...record, symbols: decoded }
+  } catch {
+    return input
+  }
+}
+
 const inferSingleSelectorPath = (input: unknown): unknown => {
   if (!input || typeof input !== 'object' || Array.isArray(input)) return input
   const record = input as Record<string, unknown>
@@ -73,7 +89,7 @@ const inferSingleSelectorPath = (input: unknown): unknown => {
 
 const inputSchema = z
   .preprocess(
-    inferSingleSelectorPath,
+    (input) => inferSingleSelectorPath(decodeFragmentedSymbolSelectors(input)),
     z.object({
       paths: z
         .preprocess(


### PR DESCRIPTION
## Summary
- expose set_output to code-reviewer, security-reviewer, and all structured specialist agents
- recover safely from provider-fragmented read_files symbol selectors
- add regression tests for both contracts

## Validation
- common, agents, and CLI typechecks
- 201 focused tests
- local-agent integration suite
- regenerated 45 bundled agents
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/6)
<!-- Reviewable:end -->
