### PR TITLE
Fix JSON-encoded structured output

### DIFF
--- a/common/src/tools/__tests__/set-output-schema.test.ts
+++ b/common/src/tools/__tests__/set-output-schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+
+import { setOutputParams } from '../params/tool/set-output'
+
+describe('set_output input schema', () => {
+  test('decodes a JSON object string inside data', () => {
+    const parsed = setOutputParams.inputSchema.safeParse({
+      data: '{"schemaVersion":1,"verdict":"NON_BLOCKING"}',
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.data).toEqual({
+        schemaVersion: 1,
+        verdict: 'NON_BLOCKING',
+      })
+    }
+  })
+
+  test.each(['not json', '[]', 'null', '"text"']) (
+    'rejects a data string that is not a JSON object: %s',
+    (data) => {
+      const parsed = setOutputParams.inputSchema.safeParse({ data })
+
+      expect(parsed.success).toBe(false)
+      if (!parsed.success) {
+        expect(parsed.error.issues).toContainEqual(
+          expect.objectContaining({ path: ['data'] }),
+        )
+      }
+    },
+  )
+})

--- a/common/src/tools/params/tool/set-output.ts
+++ b/common/src/tools/params/tool/set-output.ts
@@ -6,6 +6,18 @@ import type { $ToolParams } from '../../constants'
 
 const toolName = 'set_output'
 const endsAgentStep = false
+const decodeJsonObjectString = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+  try {
+    const decoded = JSON.parse(value) as unknown
+    if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+      return value
+    }
+    return decoded
+  } catch {
+    return value
+  }
+}
 
 // WHY `data` EXISTS IN THE INPUT SCHEMA:
 // Subagents inherit their parent's tool definitions, and because of prompt caching
@@ -23,7 +35,9 @@ const endsAgentStep = false
 // This means both `{ results: [...] }` and `{ data: { results: [...] } }` are accepted.
 const inputSchema = z
   .looseObject({
-    data: z.record(z.string(), z.any()).optional(),
+    data: z
+      .preprocess(decodeJsonObjectString, z.record(z.string(), z.any()))
+      .optional(),
   })
   .describe(
     'JSON object to set as the agent output. The shape of the parameters are specified dynamically further down in the conversation. This completely replaces any previous output. If the agent was spawned, this value will be passed back to its parent. If the agent has an outputSchema defined, the output will be validated against it.',


### PR DESCRIPTION
## Summary
- decode JSON object strings supplied through set_output.data before schema validation
- continue rejecting malformed JSON, arrays, null, and primitive values
- add focused schema regression coverage

## Validation
- common, agent-runtime, and CLI typechecks
- 27 focused tests
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/7)
<!-- Reviewable:end -->
