### PR TITLE
Fix tree-sitter grammar packaging

### DIFF
--- a/.github/workflows/cli-release-build.yml
+++ b/.github/workflows/cli-release-build.yml
@@ -304,7 +304,10 @@ jobs:
           # Bundle the binary alongside tree-sitter.wasm — the CLI loads
           # the wasm as a sibling file at runtime since bun --compile
           # asset embedding wasn't reliable on Windows.
-          FILES=("$BINARY_FILE" tree-sitter.wasm)
+          FILES=("$BINARY_FILE")
+          for wasm in cli/bin/tree-sitter*.wasm; do
+            FILES+=("$(basename "$wasm")")
+          done
           if [[ "${{ matrix.legacy_macos == true }}" == "true" ]]; then
             FILES+=(libopentui.dylib rg)
           fi
@@ -454,7 +457,11 @@ jobs:
           BINARY_FILE="${{ inputs.binary-name }}.exe"
           # Bundle tree-sitter.wasm next to the binary; see the
           # equivalent matrix-job tar step for context.
-          tar -czf ${{ inputs.binary-name }}-win32-x64.tar.gz -C cli/bin "$BINARY_FILE" tree-sitter.wasm
+          FILES=("$BINARY_FILE")
+          for wasm in cli/bin/tree-sitter*.wasm; do
+            FILES+=("$(basename "$wasm")")
+          done
+          tar -czf ${{ inputs.binary-name }}-win32-x64.tar.gz -C cli/bin "${FILES[@]}"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7

--- a/agents/__tests__/basher.test.ts
+++ b/agents/__tests__/basher.test.ts
@@ -41,6 +41,13 @@ describe('commander agent', () => {
     test('has run_terminal_command tool', () => {
       expect(commander.toolNames).toContain('run_terminal_command')
       expect(commander.toolNames).toHaveLength(1)
+      expect(commander.programmaticToolNames).toEqual(['set_output'])
+    })
+
+    test('does not promise an unavailable interactive approval path', () => {
+      expect(commander.instructionsPrompt).toContain(
+        'Do not claim the user can approve and retry this basher invocation',
+      )
     })
   })
 

--- a/agents/basher.ts
+++ b/agents/basher.ts
@@ -72,6 +72,7 @@ const basher: AgentDefinition = {
   outputMode: 'structured_output',
   includeMessageHistory: false,
   toolNames: ['run_terminal_command'],
+  programmaticToolNames: ['set_output'],
   systemPrompt: `You are an expert at reading the output of a terminal command.
 
 Your job is to:
@@ -87,7 +88,7 @@ When describing command output:
 - Don't include any follow up recommendations, suggestions, or offers to help`,
   instructionsPrompt: `The user has provided a command to run and specified what information they want from the output.
 
-Run the command and then return the relevant command result information, following the user's instructions about what to focus on.
+Run the command and then return the relevant command result information, following the user's instructions about what to focus on. If terminal policy denies the command, report that denial exactly and stop. Do not claim the user can approve and retry this basher invocation; use only the command surface allowed by the assigned terminal permission profile.
 
 Do not use any tools! Only report the output of the command.`,
   handleSteps: function* ({ params }: AgentStepContext) {

--- a/cli/scripts/build-binary.ts
+++ b/cli/scripts/build-binary.ts
@@ -18,6 +18,8 @@ import { tmpdir } from 'os'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
+import { LANGUAGE_WASM_FILES } from '../../packages/code-map/src/wasm-files'
+
 type TargetInfo = {
   bunTarget: string
   platform: NodeJS.Platform
@@ -244,6 +246,18 @@ async function main() {
   const siblingWasm = join(binDir, 'tree-sitter.wasm')
   writeFileSync(siblingWasm, readFileSync(sourceWasm))
   logAlways(`Copied tree-sitter.wasm sibling: ${sourceWasm} → ${siblingWasm}`)
+  const grammarWasmDir = findGrammarWasmDir()
+  let copiedGrammarCount = 0
+  for (const wasmFile of LANGUAGE_WASM_FILES) {
+    const source = join(grammarWasmDir, wasmFile)
+    if (!existsSync(source)) {
+      logAlways(`Skipping unavailable optional tree-sitter grammar: ${wasmFile}`)
+      continue
+    }
+    copyFileSync(source, join(binDir, wasmFile))
+    copiedGrammarCount++
+  }
+  logAlways(`Copied ${copiedGrammarCount} tree-sitter language grammars`)
 
   if (targetInfo.platform !== 'win32') {
     chmodSync(outputFile, 0o755)
@@ -330,6 +344,27 @@ function findWebTreeSitterWasm(): string {
         `\nAnd createRequire failed: ${err instanceof Error ? err.message : String(err)}`,
     )
   }
+}
+
+function findGrammarWasmDir(): string {
+  const candidates = [
+    join(repoRoot, 'node_modules', '@vscode', 'tree-sitter-wasm', 'wasm'),
+    join(cliRoot, 'node_modules', '@vscode', 'tree-sitter-wasm', 'wasm'),
+  ]
+  const requiredCoreGrammars = [
+    'tree-sitter-javascript.wasm',
+    'tree-sitter-typescript.wasm',
+    'tree-sitter-tsx.wasm',
+  ]
+  const found = candidates.find((candidate) =>
+    requiredCoreGrammars.every((file) => existsSync(join(candidate, file))),
+  )
+  if (!found) {
+    throw new Error(
+      `Could not locate packaged tree-sitter language grammars. Searched:\n  - ${candidates.join('\n  - ')}`,
+    )
+  }
+  return found
 }
 
 function patchOpenTuiAssetPaths() {

--- a/cli/src/commands/index-command.ts
+++ b/cli/src/commands/index-command.ts
@@ -160,7 +160,7 @@ function formatIndexStatus(
     status.message,
     `Corpus: ${status.totalIndexed} indexed file${status.totalIndexed === 1 ? '' : 's'}.`,
     `Age: ${status.indexAge > 0 ? formatAge(status.indexAge) : 'not available'}.`,
-    `Semantic: ${semantic}.`,
+    `Vector embeddings: ${semantic}.`,
     status.ready
       ? 'Use /index explain <query> to inspect ranking provenance.'
       : 'Retry shortly, run /index rebuild, or use read_subtree/glob/code_search.',

--- a/cli/src/components/tools/__tests__/query-index.test.tsx
+++ b/cli/src/components/tools/__tests__/query-index.test.tsx
@@ -121,7 +121,7 @@ describe('QueryIndexComponent', () => {
     const markup = renderToStaticMarkup(<>{rendered.content}</>)
 
     expect(markup).toContain('degraded · refreshing')
-    expect(markup).toContain('Semantic: failed')
+    expect(markup).toContain('Vector embeddings: failed')
     expect(markup).toContain('Partial coverage')
     expect(markup).toContain('src/bad.ts')
     expect(markup).toContain('syntax error')

--- a/cli/src/components/tools/query-index.tsx
+++ b/cli/src/components/tools/query-index.tsx
@@ -133,7 +133,7 @@ export const QueryIndexComponent = defineToolComponent({
             ) : null}
             {structuredStatus?.semantic ? (
               <text style={{ wrapMode: 'word' }}>
-                <span fg={theme.muted}>{`Semantic: ${structuredStatus.semantic}`}</span>
+                <span fg={theme.muted}>{`Vector embeddings: ${structuredStatus.semantic}`}</span>
               </text>
             ) : null}
             {coverage?.truncated ? (

--- a/cli/src/pre-init/tree-sitter-wasm.ts
+++ b/cli/src/pre-init/tree-sitter-wasm.ts
@@ -60,6 +60,7 @@ if (siblingPath) {
   // is. The locateFile callback there will hand this path to
   // emscripten, which fs.readFile's it.
   process.env.CODEBUFF_TREE_SITTER_WASM_PATH = siblingPath
+  process.env.CODEBUFF_WASM_DIR = dirname(siblingPath)
 
   // Also publish on globalThis so the smoke handler in index.tsx can
   // read it without touching process.env (which is gated by the env

--- a/common/src/tools/params/tool/run-terminal-command.ts
+++ b/common/src/tools/params/tool/run-terminal-command.ts
@@ -103,10 +103,7 @@ Stick to these use cases:
 2. Running tests (e.g., "npm test"). Reading the output can help you edit code to fix failing tests. Or, you could write new unit tests and then run them.
 3. Moving, renaming, or deleting files and directories. These actions can be vital for refactoring requests. Use commands like \`mv\`/\`move\` or \`rm\`/\`del\`.
 
-Most likely, you should ask for permission for any other type of command you want to run. If asking for permission, show the user the command you want to run using \`\`\` tags and *do not* use the tool call format, e.g.:
-\`\`\`bash
-git branch -D foo
-\`\`\`
+This tool has no interactive privilege-escalation path. Do not ask the user to approve a denied basher command and then retry it: approval text cannot change the runtime permission profile. Keep validation and inspection commands within the read-only allowlist. Use dedicated, explicitly authorized agents/workflows for git mutation, dependency installation, releases, deployment, or other high-impact operations; otherwise ask the user to run the command themselves outside the agent.
 
 DO NOT do any of the following:
 1. Run commands that can modify files outside of the project directory, install packages globally, install virtual environments, or have significant side effects outside of the project directory, unless you have explicit permission from the user. Treat anything outside of the project directory as read-only.

--- a/packages/code-map/src/languages.ts
+++ b/packages/code-map/src/languages.ts
@@ -26,6 +26,9 @@ import phpQuery from './tree-sitter-queries/tree-sitter-php-tags.scm'
 import swiftQuery from './tree-sitter-queries/tree-sitter-swift-tags.scm'
 import gdscriptQuery from './tree-sitter-queries/tree-sitter-gdscript-tags.scm'
 import { getDirnameDynamically } from './utils'
+import { WASM_FILES } from './wasm-files'
+
+export { WASM_FILES } from './wasm-files'
 
 /* ------------------------------------------------------------------ */
 /* 2. Types and interfaces                                           */
@@ -49,23 +52,6 @@ export interface RuntimeLanguageLoader {
 /* ------------------------------------------------------------------ */
 /* 3. WASM file manifest                                             */
 /* ------------------------------------------------------------------ */
-export const WASM_FILES = {
-  'tree-sitter-c-sharp.wasm': 'tree-sitter-c-sharp.wasm',
-  'tree-sitter-cpp.wasm': 'tree-sitter-cpp.wasm',
-  'tree-sitter-go.wasm': 'tree-sitter-go.wasm',
-  'tree-sitter-java.wasm': 'tree-sitter-java.wasm',
-  'tree-sitter-javascript.wasm': 'tree-sitter-javascript.wasm',
-  'tree-sitter-python.wasm': 'tree-sitter-python.wasm',
-  'tree-sitter-ruby.wasm': 'tree-sitter-ruby.wasm',
-  'tree-sitter-rust.wasm': 'tree-sitter-rust.wasm',
-  'tree-sitter-tsx.wasm': 'tree-sitter-tsx.wasm',
-  'tree-sitter-typescript.wasm': 'tree-sitter-typescript.wasm',
-  'tree-sitter-kotlin.wasm': 'tree-sitter-kotlin.wasm',
-  'tree-sitter-php.wasm': 'tree-sitter-php.wasm',
-  'tree-sitter-swift.wasm': 'tree-sitter-swift.wasm',
-  'tree-sitter-gdscript.wasm': 'tree-sitter-gdscript.wasm',
-} as const
-
 /* ------------------------------------------------------------------ */
 /* 4. Language table                                                 */
 /* ------------------------------------------------------------------ */
@@ -350,4 +336,8 @@ export async function getLanguageConfig(
     }
     return undefined
   }
+}
+
+export function hasLanguageConfiguration(filePath: string): boolean {
+  return findLanguageConfigByExtension(filePath) !== undefined
 }

--- a/packages/code-map/src/parse.ts
+++ b/packages/code-map/src/parse.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { getLanguageConfig } from './languages'
+import { getLanguageConfig, hasLanguageConfiguration } from './languages'
 
 import type { LanguageConfig } from './languages'
 import type { Parser, Query } from 'web-tree-sitter'
@@ -116,9 +116,9 @@ export async function getFileTokenScores(
         diagnostics.push({
           filePath,
           stage: 'language',
-          message: `No tree-sitter language configuration available for ${
-            path.extname(filePath) || 'file'
-          }`,
+          message: hasLanguageConfiguration(fullPath)
+            ? `Tree-sitter grammar failed to load for ${path.extname(filePath) || 'file'}. Verify the packaged language WASM files and CODEBUFF_WASM_DIR.`
+            : `No tree-sitter language configuration available for ${path.extname(filePath) || 'file'}`,
         })
         continue
       }

--- a/packages/code-map/src/wasm-files.ts
+++ b/packages/code-map/src/wasm-files.ts
@@ -1,0 +1,18 @@
+export const WASM_FILES = {
+  'tree-sitter-c-sharp.wasm': 'tree-sitter-c-sharp.wasm',
+  'tree-sitter-cpp.wasm': 'tree-sitter-cpp.wasm',
+  'tree-sitter-go.wasm': 'tree-sitter-go.wasm',
+  'tree-sitter-java.wasm': 'tree-sitter-java.wasm',
+  'tree-sitter-javascript.wasm': 'tree-sitter-javascript.wasm',
+  'tree-sitter-python.wasm': 'tree-sitter-python.wasm',
+  'tree-sitter-ruby.wasm': 'tree-sitter-ruby.wasm',
+  'tree-sitter-rust.wasm': 'tree-sitter-rust.wasm',
+  'tree-sitter-tsx.wasm': 'tree-sitter-tsx.wasm',
+  'tree-sitter-typescript.wasm': 'tree-sitter-typescript.wasm',
+  'tree-sitter-kotlin.wasm': 'tree-sitter-kotlin.wasm',
+  'tree-sitter-php.wasm': 'tree-sitter-php.wasm',
+  'tree-sitter-swift.wasm': 'tree-sitter-swift.wasm',
+  'tree-sitter-gdscript.wasm': 'tree-sitter-gdscript.wasm',
+} as const
+
+export const LANGUAGE_WASM_FILES = Object.freeze(Object.values(WASM_FILES))


### PR DESCRIPTION
## Summary
- package available tree-sitter language grammars with CLI binaries and release archives
- configure the packaged grammar directory during CLI pre-init
- distinguish unsupported languages from grammar load failures
- clarify vector-embedding status separately from parser availability
- remove the nonexistent basher approval-retry promise and keep validation within enforced terminal policy

## Validation
- compiled CLI binary successfully with 11 language grammars
- 93 focused tests
- code-map, agents, common, and CLI typechecks
- JS/TS/TSX packaged grammar smoke
- binary help smoke
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/8)
<!-- Reviewable:end -->
