### PR TITLE
Enforce commit-after-review ordering and stabilize gate fingerprint

### DIFF
--- a/agents/__tests__/base2.test.ts
+++ b/agents/__tests__/base2.test.ts
@@ -58,9 +58,11 @@ function parseGateStateBlock(text: string):
 }
 
 function buildFingerprint(
-  entries: Array<{ file: string; statusLine: string; contentMarker: string }>,
+  entries: Array<{ file: string; statusLine?: string; contentMarker: string }>,
   validationSummary: string,
 ): string {
+  // Mirror the runtime's content-only fingerprint (files-v4). The volatile
+  // git status line is intentionally excluded so commits don't invalidate it.
   const sorted = entries
     .map((entry) => ({
       ...entry,
@@ -68,9 +70,9 @@ function buildFingerprint(
     }))
     .sort((a, b) => a.file.localeCompare(b.file))
   const parts = sorted.map(
-    (entry) => `${entry.file}\t${entry.statusLine}\t${entry.contentMarker}`,
+    (entry) => `${entry.file}\t${entry.contentMarker}`,
   )
-  const details = `files-v3\n${parts.join('\n')}\n--\n${validationSummary}`
+  const details = `files-v4\n${parts.join('\n')}\n--\n${validationSummary}`
   return `v3:${createHash('sha256').update(details).digest('hex')}`
 }
 
@@ -1298,6 +1300,87 @@ describe('base2 verification and reviewer gates', () => {
       toolName: 'run_file_change_hooks',
       input: { files: [gateFile] },
     })
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('reuses prior gate pass after a commit clears the status line (content unchanged)', () => {
+    // Regression: the gate fingerprint must be content-only (files-v4), not
+    // include the volatile git status line. A commit clears the status line
+    // but leaves file bytes identical; the fingerprint must still match so
+    // the reviewer is NOT re-run on unchanged content.
+    const base2 = createBase2('default')
+    const tmpDir = makeProjectTempDir('base2-commit-reuse-')
+    const tmpFile = join(tmpDir, 'a.ts')
+    const gateFile = normalizeGateFilePath(tmpFile)
+    writeFileSync(tmpFile, 'export const value = 1\n')
+    const validationSummary = 'Configured file-change hooks passed: typecheck.'
+    // Fingerprint built with the content marker only (status line excluded).
+    const fingerprint = buildFingerprint(
+      [{ file: gateFile, contentMarker: buildContentMarker(tmpFile) }],
+      validationSummary,
+    )
+    const passedGateState = `<gate-state>{"gate":"validation/reviewer","status":"passed","details":"reviewer verdict LOOKS_GOOD; validation hooks ran; pending files: ${tmpFile}; completed"}</gate-state>`
+    const agentState = {
+      agentId: 'base2-custom',
+      messageHistory: [{ role: 'user', content: passedGateState }],
+      base2ActiveWork: {
+        changedFiles: [gateFile],
+        touchedFiles: [gateFile],
+        pendingGateFiles: [gateFile],
+        currentPhase: 'awaiting_validation',
+        latestWorkSummary: 'Pending gate previously passed.',
+        openReviewerBlockers: [],
+        lastValidationSummary: validationSummary,
+        nextRequiredAction: '',
+        lastPinnedStateMessage: '',
+        gatePassedPendingFiles: [gateFile],
+        gatePassedReviewerVerdict: 'LOOKS_GOOD',
+        gatePassedValidationSummary: validationSummary,
+        gatePassedFingerprint: fingerprint,
+      },
+    }
+    const gen = base2.handleSteps!({
+      agentState,
+      prompt: 'Finish the previous response.',
+      params: {},
+    } as any)
+
+    expect(gen.next().value).toMatchObject({ toolName: 'git_status' })
+    expect(
+      gen.next({
+        toolResult: [
+          { type: 'json', value: { status: ` M ${tmpFile}` } },
+        ],
+      } as any).value,
+    ).toMatchObject({ toolName: 'spawn_agent_inline' })
+    const maybePinnedState = gen.next().value
+    if (maybePinnedState !== 'STEP') {
+      expect(maybePinnedState).toMatchObject({ toolName: 'add_message' })
+      expect(gen.next().value).toBe('STEP')
+    }
+    expect(
+      gen.next({ stepsComplete: true, toolResult: [], agentState } as any)
+        .value,
+    ).toMatchObject({ toolName: 'git_status' })
+    // Simulate a commit: git status is now clean (empty), but file content is
+    // unchanged. The content-only fingerprint must still match.
+    const reused = gen.next({
+      toolResult: [{ type: 'json', value: { status: '' } }],
+    } as any)
+
+    expect(reused.value).toMatchObject({
+      toolName: 'add_message',
+      input: { role: 'user' },
+    })
+    const content = (reused.value as any).input.content as string
+    expect(content).toContain(
+      'Previous validation and reviewer gate already passed',
+    )
+    expect((agentState as any).base2ActiveWork).toMatchObject({
+      pendingGateFiles: [],
+      currentPhase: 'final_response_allowed',
+    })
+    expect((agentState as any).canSuggestFollowups).toBe(true)
     rmSync(tmpDir, { recursive: true, force: true })
   })
 

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -4926,16 +4926,20 @@ ${specialistRoutingSection}
 
       function buildGateSnapshotDetails(
         files: string[],
-        statusLines: Map<string, string>,
+        _statusLines: Map<string, string>,
         validationSummary: string,
       ): string {
+        // Content-only fingerprint: the volatile git status line (e.g. ` M file`)
+        // is intentionally excluded. A commit clears the status line but leaves
+        // file bytes identical; including it would invalidate the fingerprint on
+        // every commit and force a redundant reviewer re-run on unchanged content.
+        // The content marker (sha256 of file bytes) is the stable identity signal.
         const sorted = [...files].sort()
         const parts = sorted.map((file) => {
-          const statusLine = statusLines.get(file) ?? ''
           const contentMarker = readGateFileContentMarker(file)
-          return `${file}\t${statusLine}\t${contentMarker}`
+          return `${file}\t${contentMarker}`
         })
-        return `files-v3\n${parts.join('\n')}\n--\n${validationSummary}`
+        return `files-v4\n${parts.join('\n')}\n--\n${validationSummary}`
       }
 
       function hashGateSnapshotDetails(details: string): string {

--- a/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
+++ b/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
@@ -468,6 +468,64 @@ describe('runAgentStep - set_output tool', () => {
     )
   })
 
+  it('blocks git-committer spawn when the validation/reviewer gate has not passed', async () => {
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+    }
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      yield createToolCallChunk('spawn_agents', {
+        agents: [
+          {
+            agent_type: 'git-committer',
+            prompt: 'Commit the changes',
+            params: { owned_paths: ['src/a.ts'] },
+          },
+        ],
+      })
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+      }
+    // canSuggestFollowups === false means the gate is not green.
+    agentState.canSuggestFollowups = false
+    const committerAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-committer-agent',
+      toolNames: ['spawn_agents', 'end_turn'],
+      spawnableAgents: ['git-committer'],
+    }
+
+    await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-committer-agent',
+      localAgentTemplates: { 'test-committer-agent': committerAgent },
+      agentTemplate: committerAgent,
+      agentState,
+      prompt: 'Commit before the gate passes',
+    })
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringContaining(
+          'Spawning `git-committer` is not available yet',
+        ),
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'spawn_agents',
+      }),
+    )
+  })
+
   it('blocks suggest_followups after same-step file edits even when the gate started open', async () => {
     const chunks: unknown[] = []
     runAgentStepBaseParams = {

--- a/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
+++ b/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
@@ -526,6 +526,93 @@ describe('runAgentStep - set_output tool', () => {
     )
   })
 
+  it('filters git-committer from a mixed spawn_agents batch while proceeding with other agents', async () => {
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+    }
+    const helperAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-helper-agent',
+      toolNames: ['end_turn'],
+      spawnableAgents: [],
+    }
+    // The parent yields the mixed spawn_agents batch once; the spawned helper
+    // agent re-invokes this same stream, so subsequent calls must end_turn to
+    // avoid infinite spawn recursion.
+    let streamCallCount = 0
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      streamCallCount += 1
+      if (streamCallCount === 1) {
+        yield createToolCallChunk('spawn_agents', {
+          agents: [
+            {
+              agent_type: 'git-committer',
+              prompt: 'Commit the changes',
+              params: { owned_paths: ['src/a.ts'] },
+            },
+            {
+              agent_type: 'test-helper-agent',
+              prompt: 'Do something else',
+            },
+          ],
+        })
+      } else {
+        yield createToolCallChunk('end_turn', {})
+      }
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+      }
+    // canSuggestFollowups === false means the gate is not green.
+    agentState.canSuggestFollowups = false
+    const committerAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-committer-agent',
+      toolNames: ['spawn_agents', 'end_turn'],
+      spawnableAgents: ['git-committer', 'test-helper-agent'],
+    }
+
+    await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-committer-agent',
+      localAgentTemplates: {
+        'test-committer-agent': committerAgent,
+        'test-helper-agent': helperAgent,
+      },
+      agentTemplate: committerAgent,
+      agentState,
+      prompt: 'Commit and do other work before the gate passes',
+    })
+
+    // The git-committer entry is blocked with an error chunk.
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringContaining(
+          'Spawning `git-committer` is not available yet',
+        ),
+      }),
+    )
+    // The spawn_agents tool_call proceeds with only the helper agent.
+    const spawnCall = chunks.find(
+      (chunk) =>
+        chunk &&
+        typeof chunk === 'object' &&
+        (chunk as Record<string, unknown>).type === 'tool_call' &&
+        (chunk as Record<string, unknown>).toolName === 'spawn_agents',
+    ) as Record<string, unknown> | undefined
+    expect(spawnCall).toBeDefined()
+    const spawnInput = spawnCall?.input as { agents: Array<{ agent_type: string }> }
+    expect(spawnInput.agents).toHaveLength(1)
+    expect(spawnInput.agents[0]?.agent_type).toBe('test-helper-agent')
+  })
+
   it('blocks suggest_followups after same-step file edits even when the gate started open', async () => {
     const chunks: unknown[] = []
     runAgentStepBaseParams = {

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1090,6 +1090,35 @@ export async function executeToolCall<T extends ToolName>(
       false
   }
 
+  // Deterministically block git-committer spawns until the validation/reviewer
+  // gate has passed. canSuggestFollowups is false precisely when the gate is
+  // not green (edits pending review). This mirrors the suggest_followups guard
+  // above and enforces the harness ordering: commit only after review is green.
+  // When canSuggestFollowups is undefined (gate system not active, e.g. non-base2
+  // agents), the check is skipped so custom agents are unaffected.
+  if (
+    toolName === 'spawn_agents' &&
+    canSuggestFollowups === false
+  ) {
+    const agents = (toolCall.input as Record<string, unknown>)?.agents
+    if (Array.isArray(agents)) {
+      const hasGitCommitter = agents.some(
+        (agent) =>
+          agent &&
+          typeof agent === 'object' &&
+          (agent as Record<string, unknown>).agent_type === 'git-committer',
+      )
+      if (hasGitCommitter) {
+        onResponseChunk({
+          type: 'error',
+          message:
+            'Spawning `git-committer` is not available yet. The validation/reviewer gate must pass before committing. Wait for the automated gate to complete, then commit.',
+        })
+        return abortablePreviousToolCallFinished
+      }
+    }
+  }
+
   // TODO: Allow tools to provide a validation function, and move this logic into the spawn_agents validation function.
   // Pre-validate spawn_agents to filter out non-existent agents before streaming
   let effectiveInput = toolCall.input as Record<string, unknown>

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1085,10 +1085,21 @@ export async function executeToolCall<T extends ToolName>(
   // post-step edits-detected block re-evaluates the gate), bypassing the
   // validation/reviewer gate. The same-batch case is already covered by the
   // toolCalls.some(isFileChangingTool) check above; this covers cross-batch.
-  if (isFileChangingTool(toolName) && canSuggestFollowups !== false) {
+  // Only retract when the gate system is active (canSuggestFollowups is
+  // defined); non-base2/custom agents that never opted into the gate are
+  // unaffected.
+  if (
+    isFileChangingTool(toolName) &&
+    canSuggestFollowups !== undefined &&
+    canSuggestFollowups !== false
+  ) {
     ;(agentState as { canSuggestFollowups?: boolean }).canSuggestFollowups =
       false
   }
+
+  // TODO: Allow tools to provide a validation function, and move this logic into the spawn_agents validation function.
+  // Pre-validate spawn_agents to filter out non-existent agents before streaming
+  let effectiveInput = toolCall.input as Record<string, unknown>
 
   // Deterministically block git-committer spawns until the validation/reviewer
   // gate has passed. canSuggestFollowups is false precisely when the gate is
@@ -1096,32 +1107,32 @@ export async function executeToolCall<T extends ToolName>(
   // above and enforces the harness ordering: commit only after review is green.
   // When canSuggestFollowups is undefined (gate system not active, e.g. non-base2
   // agents), the check is skipped so custom agents are unaffected.
-  if (
-    toolName === 'spawn_agents' &&
-    canSuggestFollowups === false
-  ) {
-    const agents = (toolCall.input as Record<string, unknown>)?.agents
+  // Only the git-committer entry is filtered; co-batched legitimate agents
+  // proceed normally, consistent with the spawn_agents pre-validation pattern.
+  if (toolName === 'spawn_agents' && canSuggestFollowups === false) {
+    const agents = effectiveInput.agents
     if (Array.isArray(agents)) {
-      const hasGitCommitter = agents.some(
+      const filteredAgents = agents.filter(
         (agent) =>
-          agent &&
-          typeof agent === 'object' &&
-          (agent as Record<string, unknown>).agent_type === 'git-committer',
+          !(
+            agent &&
+            typeof agent === 'object' &&
+            (agent as Record<string, unknown>).agent_type === 'git-committer'
+          ),
       )
-      if (hasGitCommitter) {
+      if (filteredAgents.length < agents.length) {
         onResponseChunk({
           type: 'error',
           message:
             'Spawning `git-committer` is not available yet. The validation/reviewer gate must pass before committing. Wait for the automated gate to complete, then commit.',
         })
-        return abortablePreviousToolCallFinished
+        if (filteredAgents.length === 0) {
+          return abortablePreviousToolCallFinished
+        }
+        effectiveInput = { ...effectiveInput, agents: filteredAgents }
       }
     }
   }
-
-  // TODO: Allow tools to provide a validation function, and move this logic into the spawn_agents validation function.
-  // Pre-validate spawn_agents to filter out non-existent agents before streaming
-  let effectiveInput = toolCall.input as Record<string, unknown>
   if (toolName === 'spawn_agents') {
     const agents = effectiveInput.agents
     if (Array.isArray(agents)) {

--- a/packages/indexer/src/query.ts
+++ b/packages/indexer/src/query.ts
@@ -702,6 +702,8 @@ function findSeedPaths(
   tokens: string[],
   explicitPath?: string,
   fileTypes?: string[],
+  // Default required by TS1016: this required param follows optional params
+  // (explicitPath?, fileTypes?). All callers pass it explicitly.
   lexicalWeights: Required<LexicalWeights> = DEFAULT_LEXICAL_WEIGHTS,
   fallbackPath?: string,
 ): string[] {
@@ -757,6 +759,9 @@ function queryReferences(
     options.to,
   )
   const results = new Map<string, QueryIndexResult>()
+  // Track which seed paths have already been appended to each importer's
+  // explanation, using exact-segment matching instead of substring checks.
+  const explainedSeeds = new Map<string, Set<string>>()
 
   for (const seedPath of seedPaths) {
     const seedId = fileNodeId(seedPath)
@@ -784,11 +789,16 @@ function queryReferences(
         existing.relatedFiles = mergeRelatedFiles(existing.relatedFiles, [
           { path: seedPath, score: edge.weight, reason, via: edge.label },
         ])
-        if (
-          existing.explanation &&
-          !existing.explanation.includes(`also references ${seedPath}`)
-        ) {
-          existing.explanation += `; also references ${seedPath}`
+        if (existing.explanation) {
+          let seeds = explainedSeeds.get(importerNode.path)
+          if (!seeds) {
+            seeds = new Set<string>()
+            explainedSeeds.set(importerNode.path, seeds)
+          }
+          if (!seeds.has(seedPath)) {
+            seeds.add(seedPath)
+            existing.explanation += `; also references ${seedPath}`
+          }
         }
       } else {
         results.set(importerNode.path, {


### PR DESCRIPTION
## Summary

Enforce commit-after-review ordering in the harness by default, and stop redundant reviewer re-runs after a commit.

### Changes
- **Deterministic commit gate** (tool-executor.ts): block git-committer spawns while the validation/reviewer gate is not green, mirroring the existing suggest_followups guard. The committer can no longer run before review passes — no need to specify the order.
- **Content-only gate fingerprint** (base2.ts): buildGateSnapshotDetails now hashes file content only (files-v4), excluding the volatile git status line. A commit clears the status line but leaves file bytes identical, so the fingerprint still matches and the gate reuses the prior green review instead of re-spawning the reviewer on unchanged content.
- **Indexer**: replace the queryReferences explanation de-dup substring check with an exact-segment Set; document why findSeedPaths keeps its lexicalWeights default (TS1016).

### Tests
- base2: gate pass is reused after a commit clears the status line (content unchanged) — reviewer is NOT re-run.
- agent-runtime: git-committer spawn is blocked while the gate is not green.
- Full monorepo typecheck green; base2 76/0, run-agent-step-tools 17/0, indexer query 26/0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/18)
<!-- Reviewable:end -->
