### PR TITLE
Make git-committer pre-gate alias-safe and optimize spawn payload check

### DIFF
--- a/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
+++ b/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
@@ -613,6 +613,73 @@ describe('runAgentStep - set_output tool', () => {
     expect(spawnInput.agents[0]?.agent_type).toBe('test-helper-agent')
   })
 
+  it('warns when a spawn_agents entry exceeds the soft payload size limit', async () => {
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+    }
+    // Spy on the logger threaded into executeToolCall so we can assert the
+    // soft payload-size warning fires for the oversized entry only.
+    const baseLogger = (runAgentStepBaseParams as unknown as {
+      logger: { warn: (...args: unknown[]) => void }
+    }).logger
+    const warnSpy = spyOn(baseLogger, 'warn').mockImplementation(() => {})
+
+    const helperAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-helper-agent',
+      toolNames: ['end_turn'],
+      spawnableAgents: [],
+    }
+    // One oversized entry (>4KB serialized) and one small entry. The parent
+    // yields the batch once; the spawned helper re-invokes this stream, so
+    // subsequent calls end_turn to avoid infinite spawn recursion.
+    const largeBody = 'x'.repeat(5000)
+    let streamCallCount = 0
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      streamCallCount += 1
+      if (streamCallCount === 1) {
+        yield createToolCallChunk('spawn_agents', {
+          agents: [
+            { agent_type: 'test-helper-agent', prompt: largeBody },
+            { agent_type: 'test-helper-agent', prompt: 'small' },
+          ],
+        })
+      } else {
+        yield createToolCallChunk('end_turn', {})
+      }
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const agentState = sessionState.mainAgentState
+    const committerAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-committer-agent',
+      toolNames: ['spawn_agents', 'end_turn'],
+      spawnableAgents: ['test-helper-agent'],
+    }
+
+    await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-committer-agent',
+      localAgentTemplates: {
+        'test-committer-agent': committerAgent,
+        'test-helper-agent': helperAgent,
+      },
+      agentTemplate: committerAgent,
+      agentState,
+      prompt: 'Spawn with a large payload',
+    })
+
+    // Exactly the oversized entry triggers the soft payload-size warning.
+    const payloadWarnings = warnSpy.mock.calls.filter((call) =>
+      String(call[1] ?? '').includes('exceeds the soft payload size limit'),
+    )
+    expect(payloadWarnings).toHaveLength(1)
+  })
+
   it('blocks suggest_followups after same-step file edits even when the gate started open', async () => {
     const chunks: unknown[] = []
     runAgentStepBaseParams = {

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1117,7 +1117,12 @@ export async function executeToolCall<T extends ToolName>(
           !(
             agent &&
             typeof agent === 'object' &&
-            (agent as Record<string, unknown>).agent_type === 'git-committer'
+            typeof (agent as Record<string, unknown>).agent_type === 'string' &&
+            // Match on the resolved agent id so a git-committer alias cannot
+            // bypass the pre-gate block (consistent with spawn resolution).
+            normalizeSpawnAgentType(
+              String((agent as Record<string, unknown>).agent_type),
+            ) === 'git-committer'
           ),
       )
       if (filteredAgents.length < agents.length) {
@@ -1143,7 +1148,37 @@ export async function executeToolCall<T extends ToolName>(
       // disrupting the call. The prompt guard (Fix A) is the primary
       // prevention; this is the safety net.
       const MAX_SINGLE_AGENT_PAYLOAD_CHARS = 4_000
+      // Cheap recursive pre-screen: only pay for a full JSON.stringify when an
+      // entry's accumulated string/key content could plausibly reach the limit.
+      // This avoids serializing every (typically small) agent entry on the hot
+      // spawn path. The walk early-exits at the limit, so any entry with >= limit
+      // chars of string/key content still gets the exact serialized-length check.
+      const couldExceedPayloadLimit = (value: unknown): boolean => {
+        let total = 0
+        const walk = (node: unknown): boolean => {
+          if (typeof node === 'string') {
+            total += node.length
+            return total >= MAX_SINGLE_AGENT_PAYLOAD_CHARS
+          }
+          if (Array.isArray(node)) {
+            for (const item of node) {
+              if (walk(item)) return true
+            }
+            return false
+          }
+          if (node && typeof node === 'object') {
+            for (const [key, val] of Object.entries(node)) {
+              total += key.length
+              if (total >= MAX_SINGLE_AGENT_PAYLOAD_CHARS) return true
+              if (walk(val)) return true
+            }
+          }
+          return false
+        }
+        return walk(value)
+      }
       for (const agent of agents) {
+        if (!couldExceedPayloadLimit(agent)) continue
         let serialized: string
         try {
           serialized = JSON.stringify(agent)

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1148,17 +1148,21 @@ export async function executeToolCall<T extends ToolName>(
       // disrupting the call. The prompt guard (Fix A) is the primary
       // prevention; this is the safety net.
       const MAX_SINGLE_AGENT_PAYLOAD_CHARS = 4_000
-      // Cheap recursive pre-screen: only pay for a full JSON.stringify when an
-      // entry's accumulated string/key content could plausibly reach the limit.
-      // This avoids serializing every (typically small) agent entry on the hot
-      // spawn path. The walk early-exits at the limit, so any entry with >= limit
-      // chars of string/key content still gets the exact serialized-length check.
+      // Conservative pre-screen threshold: JSON.stringify adds structural
+      // overhead (quotes, braces, commas, escaping) on top of the raw
+      // string/key content, so an entry whose raw content is somewhat below the
+      // limit can still serialize past it. Trigger the exact serialized-length
+      // check at half the limit so near-boundary oversized entries are not
+      // missed, while still skipping truly small entries on the hot spawn path.
+      const PAYLOAD_PRESCREEN_CHARS = Math.floor(
+        MAX_SINGLE_AGENT_PAYLOAD_CHARS / 2,
+      )
       const couldExceedPayloadLimit = (value: unknown): boolean => {
         let total = 0
         const walk = (node: unknown): boolean => {
           if (typeof node === 'string') {
             total += node.length
-            return total >= MAX_SINGLE_AGENT_PAYLOAD_CHARS
+            return total >= PAYLOAD_PRESCREEN_CHARS
           }
           if (Array.isArray(node)) {
             for (const item of node) {
@@ -1169,7 +1173,7 @@ export async function executeToolCall<T extends ToolName>(
           if (node && typeof node === 'object') {
             for (const [key, val] of Object.entries(node)) {
               total += key.length
-              if (total >= MAX_SINGLE_AGENT_PAYLOAD_CHARS) return true
+              if (total >= PAYLOAD_PRESCREEN_CHARS) return true
               if (walk(val)) return true
             }
           }


### PR DESCRIPTION
## Summary

Hardening follow-ups for the spawn_agents gate in tool-executor.ts.

### Changes
- **Alias-safe committer gate**: the git-committer pre-gate block now matches on `normalizeSpawnAgentType(agent_type)` instead of the literal `git-committer` string, so a committer alias cannot bypass the gate (consistent with how spawn resolution canonicalizes agent types).
- **Optimized payload-size warning**: added a cheap recursive pre-screen (`couldExceedPayloadLimit`) that only runs the full `JSON.stringify` when an entry accumulated string/key content could plausibly reach the 4KB limit (with early-exit), avoiding serializing every small agent entry on the hot spawn path.

### Audit note
- Confirmed the key ordering rule (commit only after the gate is green) is already deterministically enforced by the git-committer spawn gate from PR #18. Remaining advisory rules (secret scanning, manual-reviewer judgment calls, pre-edit security review) are correctly advisory by design.

### Tests
- Full monorepo typecheck green; run-agent-step-tools 18/0 (git-committer gate tests pass through the normalization).
- Automated reviewer gate passed (NON_BLOCKING).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/19)
<!-- Reviewable:end -->
