### PR TITLE
Test symbolMatchesToken guard; cap payload walk depth and marker cache

### DIFF
--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -5044,6 +5044,15 @@ ${specialistRoutingSection}
             cache?: Map<string, string>
           }
           if (!cacheSlot.cache) cacheSlot.cache = new Map<string, string>()
+          // Bound the cache so a long-lived serialized generator touching many
+          // files cannot grow it without limit. Map preserves insertion order,
+          // so evict the oldest entry once the cap is reached. A cache miss only
+          // costs a re-read+hash, so eviction is safe.
+          const MAX_MARKER_CACHE_ENTRIES = 1000
+          if (cacheSlot.cache.size >= MAX_MARKER_CACHE_ENTRIES) {
+            const oldestKey = cacheSlot.cache.keys().next().value
+            if (oldestKey !== undefined) cacheSlot.cache.delete(oldestKey)
+          }
           cacheSlot.cache.set(cacheKey, marker)
           return marker
         } catch (err) {

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1157,16 +1157,22 @@ export async function executeToolCall<T extends ToolName>(
       const PAYLOAD_PRESCREEN_CHARS = Math.floor(
         MAX_SINGLE_AGENT_PAYLOAD_CHARS / 2,
       )
+      // Depth cap guards against pathological/cyclic object graphs if this
+      // walk is ever reused on untrusted (non-JSON) input. Parsed JSON is
+      // acyclic and agent payloads are shallow, so the cap is never hit in
+      // practice; beyond it we stop descending (treated as not-oversized).
+      const MAX_PAYLOAD_WALK_DEPTH = 64
       const couldExceedPayloadLimit = (value: unknown): boolean => {
         let total = 0
-        const walk = (node: unknown): boolean => {
+        const walk = (node: unknown, depth: number): boolean => {
+          if (depth > MAX_PAYLOAD_WALK_DEPTH) return false
           if (typeof node === 'string') {
             total += node.length
             return total >= PAYLOAD_PRESCREEN_CHARS
           }
           if (Array.isArray(node)) {
             for (const item of node) {
-              if (walk(item)) return true
+              if (walk(item, depth + 1)) return true
             }
             return false
           }
@@ -1174,12 +1180,12 @@ export async function executeToolCall<T extends ToolName>(
             for (const [key, val] of Object.entries(node)) {
               total += key.length
               if (total >= PAYLOAD_PRESCREEN_CHARS) return true
-              if (walk(val)) return true
+              if (walk(val, depth + 1)) return true
             }
           }
           return false
         }
-        return walk(value)
+        return walk(value, 0)
       }
       for (const agent of agents) {
         if (!couldExceedPayloadLimit(agent)) continue

--- a/packages/indexer/src/query.test.ts
+++ b/packages/indexer/src/query.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateQueryIndexQuality,
   queryIndex,
   resolveLexicalWeights,
+  symbolMatchesToken,
 } from './query'
 
 import type { MetadataIndex } from './types'
@@ -585,3 +586,23 @@ function makeCommandIndex(): MetadataIndex {
     graph: { nodes: {}, edges: [] },
   }
 }
+
+describe('symbolMatchesToken', () => {
+  test('matches when the token is a substring of the symbol (forward)', () => {
+    expect(symbolMatchesToken('authprovider', 'auth')).toBe(true)
+  })
+
+  test('matches a substantial symbol (>= 4 chars) inside the token (reverse)', () => {
+    expect(symbolMatchesToken('user', 'getuser')).toBe(true)
+  })
+
+  test('does not reverse-match a short symbol (< 4 chars) inside the token', () => {
+    // 'db' is only 2 chars, so it must not match a token that merely contains
+    // it; the reverse-substring rule only applies to symbols >= 4 chars.
+    expect(symbolMatchesToken('db', 'somedbthing')).toBe(false)
+  })
+
+  test('does not match unrelated symbol and token', () => {
+    expect(symbolMatchesToken('login', 'auth')).toBe(false)
+  })
+})

--- a/packages/indexer/src/query.ts
+++ b/packages/indexer/src/query.ts
@@ -530,7 +530,7 @@ function computeIdfForTokens(
  * case; the reverse (symbol inside the token) is only allowed for substantial
  * symbols (>= 4 chars) — otherwise a 1-2 char symbol matches almost every token.
  */
-function symbolMatchesToken(symLower: string, token: string): boolean {
+export function symbolMatchesToken(symLower: string, token: string): boolean {
   return (
     symLower.includes(token) ||
     (symLower.length >= 4 && token.includes(symLower))


### PR DESCRIPTION
## Summary

Hardening follow-ups (round 2) across the indexer, agent-runtime, and base2 gate.

### Changes
- **symbolMatchesToken test coverage**: exported `symbolMatchesToken` from the indexer query module and added a dedicated unit test covering the >=4-char reverse-substring guard (forward substring, reverse substantial-symbol match, short-symbol rejection, unrelated non-match). The rare-token IDF weighting was already covered by query-idf.test.ts; the reverse-substring branch had no direct test.
- **Payload walk depth cap**: added `MAX_PAYLOAD_WALK_DEPTH = 64` to the `couldExceedPayloadLimit` recursive walk in tool-executor.ts so it stays robust if ever reused on untrusted (non-JSON) object graphs; parsed JSON is acyclic so the cap is never hit in practice.
- **Bounded marker cache**: capped the `readGateFileContentMarker` cache in base2.ts at 1000 entries, evicting the oldest (Map insertion order) when full, so a long-lived serialized generator touching many files cannot grow it unbounded; a miss only costs a re-read+hash, so eviction is safe.

### Tests
- Full monorepo typecheck green; indexer query tests 30/0 (incl. 4 new symbolMatchesToken tests); run-agent-step-tools 19/0.
- Automated reviewer gate passed (LOOKS_GOOD).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/20)
<!-- Reviewable:end -->
