### PR TITLE
Restore OpenTUI native loader before legacy patch to fix cache poisoning

### DIFF
--- a/cli/scripts/build-binary.ts
+++ b/cli/scripts/build-binary.ts
@@ -21,7 +21,10 @@ import { fileURLToPath } from 'url'
 
 import { resolveGrammarWasmSource } from '../../packages/code-map/src/grammar-wasm-repair'
 import { LANGUAGE_WASM_FILES } from '../../packages/code-map/src/wasm-files'
-import { patchOpenTuiLegacyNativeLoaderSource } from './open-tui-legacy-patch'
+import {
+  patchOpenTuiLegacyNativeLoaderSource,
+  restoreOpenTuiNativeLoaderSource,
+} from './open-tui-legacy-patch'
 
 type TargetInfo = {
   bunTarget: string
@@ -162,6 +165,7 @@ async function main() {
   })
 
   patchOpenTuiAssetPaths()
+  restoreOpenTuiCoreNativeLoader()
   if (IS_LEGACY_MACOS_BUILD) {
     assertLegacyMacOSBuildConfig(targetInfo)
     patchOpenTuiCoreNativeLoaderForLegacy()
@@ -300,6 +304,33 @@ function assertLegacyMacOSBuildConfig(targetInfo: TargetInfo) {
     throw new Error(
       'OPENBUFF_LEGACY_RIPGREP_BIN must point to a macOS 11-compatible rg binary',
     )
+  }
+}
+
+function restoreOpenTuiCoreNativeLoader() {
+  const coreDirs = [
+    join(repoRoot, 'node_modules', '@opentui', 'core'),
+    join(cliRoot, 'node_modules', '@opentui', 'core'),
+  ]
+  const searchedFiles = new Set<string>()
+
+  for (const coreDir of coreDirs) {
+    if (!existsSync(coreDir)) continue
+    for (const file of readdirSync(coreDir)) {
+      if (!file.startsWith('index') || !file.endsWith('.js')) continue
+      const bundlePath = join(coreDir, file)
+      if (searchedFiles.has(bundlePath)) continue
+      searchedFiles.add(bundlePath)
+
+      const source = readFileSync(bundlePath, 'utf8')
+      const restored = restoreOpenTuiNativeLoaderSource(source)
+      if (restored !== source) {
+        writeFileSync(bundlePath, restored)
+        logAlways(
+          `Restored OpenTUI native loader (reverted stale legacy patch): ${bundlePath}`,
+        )
+      }
+    }
   }
 }
 

--- a/cli/scripts/open-tui-legacy-patch.ts
+++ b/cli/scripts/open-tui-legacy-patch.ts
@@ -19,3 +19,16 @@ export function patchOpenTuiLegacyNativeLoaderSource(source: string): string {
 
   return source.replace(OPEN_TUI_PLATFORM_IMPORT, LEGACY_NATIVE_LOADER)
 }
+
+const CANONICAL_NATIVE_LOADER =
+  'var module = await import(`@opentui/core-${process.platform}-${process.arch}/index.ts`);\n' +
+  'var targetLibPath = module.default;'
+
+/**
+ * Reverts a stale legacy patch left in a shared/cached node_modules so the
+ * non-legacy build compiles OpenTUI's canonical platform loader.
+ */
+export function restoreOpenTuiNativeLoaderSource(source: string): string {
+  if (!source.includes(LEGACY_NATIVE_LOADER)) return source
+  return source.replace(LEGACY_NATIVE_LOADER, CANONICAL_NATIVE_LOADER)
+}

--- a/cli/src/__tests__/open-tui-legacy-patch.test.ts
+++ b/cli/src/__tests__/open-tui-legacy-patch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { patchOpenTuiLegacyNativeLoaderSource } from '../../scripts/open-tui-legacy-patch'
+import {
+  patchOpenTuiLegacyNativeLoaderSource,
+  restoreOpenTuiNativeLoaderSource,
+} from '../../scripts/open-tui-legacy-patch'
 
 const PLATFORM_LOADER = `
 // src/zig.ts
@@ -32,5 +35,26 @@ describe('legacy OpenTUI bundle patch', () => {
         `${PLATFORM_LOADER}\n${PLATFORM_LOADER}`,
       ),
     ).toThrow('Expected exactly one OpenTUI platform loader, found 2')
+  })
+
+  test('restores the canonical loader after a legacy patch (round-trip)', () => {
+    const patched = patchOpenTuiLegacyNativeLoaderSource(PLATFORM_LOADER)
+    const restored = restoreOpenTuiNativeLoaderSource(patched)
+
+    expect(restored).toContain('@opentui/core-')
+    expect(restored).toContain('await import')
+    expect(restored).not.toContain('process.execPath.lastIndexOf')
+  })
+
+  test('is a no-op on an unpatched (canonical) bundle', () => {
+    expect(restoreOpenTuiNativeLoaderSource(PLATFORM_LOADER)).toBe(
+      PLATFORM_LOADER,
+    )
+  })
+
+  test('does not throw when the legacy loader is absent', () => {
+    expect(() =>
+      restoreOpenTuiNativeLoaderSource('var unrelated = 1'),
+    ).not.toThrow()
   })
 })


### PR DESCRIPTION
The legacy macOS build lane patches node_modules/@opentui/core/index-*.js in place to load a sibling libopentui.dylib, but the shared dependency cache key does not distinguish legacy from non-legacy lanes. The non-legacy lane can therefore restore the patched node_modules and compile a binary that expects a libopentui.dylib it never ships (smoke test: "opentui is not supported on the current platform: darwin-arm64").

Add restoreOpenTuiNativeLoaderSource, which reverts the legacy loader to the canonical platform loader and is a no-op when it is absent, and call restoreOpenTuiCoreNativeLoader() before the legacy branch so both lanes compile the canonical loader. Add round-trip, no-op, and no-throw tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/22)
<!-- Reviewable:end -->
