### PR TITLE
Dedup background job errors by flag and assert job-state mapper exhaustiveness

### DIFF
--- a/cli/src/types/chat.ts
+++ b/cli/src/types/chat.ts
@@ -81,6 +81,13 @@ export type AgentContentBlock = {
   spawnIndex?: number
   /** Detached background-agent job associated with this card. */
   backgroundJobId?: string
+  /**
+   * True once a background job error has been appended to this agent card's
+   * blocks. Prevents duplicate error text if an error/lost job_update is
+   * delivered more than once. Omitted/undefined for blocks without a
+   * background job error (treated as not-yet-appended).
+   */
+  jobErrorAppended?: boolean
 }
 export type AgentListContentBlock = {
   type: 'agent-list'

--- a/cli/src/utils/__tests__/sdk-event-handlers.test.ts
+++ b/cli/src/utils/__tests__/sdk-event-handlers.test.ts
@@ -717,6 +717,60 @@ describe('sdk-event-handlers', () => {
     expect(errorTextBlocks.length).toBe(1)
   })
 
+  test('job_update still appends an agent job error whose text coincidentally matches trailing streamed output', () => {
+    const { ctx, getMessages } = createTestContext()
+    const handleEvent = createEventHandler(ctx)
+    const handleChunk = createStreamChunkHandler(ctx)
+    // Pins the agent-block flag dedup's advantage over comparing the last text
+    // block's content: when the agent's own streamed output happens to equal
+    // the error text, a genuinely new error must still be appended. The old
+    // string comparison would see the trailing text block match the truncated
+    // error and suppress the append.
+    handleEvent({
+      type: 'subagent_start',
+      agentId: 'agent-coincidental',
+      agentType: 'researcher-web',
+      displayName: 'Researcher',
+      onlyChild: true,
+    } as any)
+    ctx.message.updater.updateAiMessageBlocks((blocks) =>
+      blocks.map((block) =>
+        block.type === 'agent' && block.agentId === 'agent-coincidental'
+          ? { ...block, backgroundJobId: 'job-agent-coincidental' }
+          : block,
+      ),
+    )
+
+    // Streamed agent output whose text coincidentally equals the error text.
+    handleChunk({
+      type: 'subagent_chunk',
+      agentId: 'agent-coincidental',
+      agentType: 'researcher-web',
+      chunk: 'agent crashed',
+    })
+    // A genuinely new error carrying the same text; it must still be appended.
+    handleEvent({
+      type: 'job_update',
+      jobId: 'job-agent-coincidental',
+      kind: 'agent',
+      state: 'error',
+      sequence: 1,
+      error: 'agent crashed',
+    } as any)
+
+    const agentBlock = getMessages()[0].blocks?.[0] as any
+    expect(agentBlock).toMatchObject({ type: 'agent', status: 'failed' })
+    const errorTextBlocks = (agentBlock.blocks ?? []).filter(
+      (b: any) => b.type === 'text' && b.content === 'agent crashed',
+    )
+    // Once from the streamed output, once from the appended error.
+    expect(errorTextBlocks.length).toBe(2)
+    expect(agentBlock.blocks?.[agentBlock.blocks.length - 1]).toMatchObject({
+      type: 'text',
+      content: 'agent crashed',
+    })
+  })
+
   test('persists context compaction details in the assistant message', () => {
     const { ctx, getMessages } = createTestContext()
     const handleEvent = createEventHandler(ctx)

--- a/cli/src/utils/sdk-event-handlers.ts
+++ b/cli/src/utils/sdk-event-handlers.ts
@@ -782,6 +782,10 @@ const jobStateToToolLifecycle = (
     case 'stopped':
     case 'cancelled':
       return 'cancelled'
+    default: {
+      const exhaustive: never = state
+      throw new Error(`Unhandled job state for tool lifecycle: ${String(exhaustive)}`)
+    }
   }
 }
 
@@ -805,6 +809,10 @@ const jobStateToAgentStatus = (
     case 'stopped':
     case 'cancelled':
       return 'cancelled'
+    default: {
+      const exhaustive: never = state
+      throw new Error(`Unhandled job state for agent status: ${String(exhaustive)}`)
+    }
   }
 }
 
@@ -842,9 +850,11 @@ const handleJobUpdate = (
         if (errorText !== undefined) {
           const truncatedError = errorText.split('\n').slice(0, 6).join('\n')
           const existingBlocks = block.blocks ?? []
-          const lastChild = existingBlocks[existingBlocks.length - 1]
-          const alreadyAppended =
-            lastChild?.type === 'text' && lastChild.content === truncatedError
+          // Mirror the tool-block flag-based dedup: track whether the error has
+          // already been appended via an explicit flag rather than comparing the
+          // last text block's content, so a genuinely new identical error is not
+          // suppressed when the prior block coincidentally matches.
+          const alreadyAppended = block.jobErrorAppended === true
           return {
             ...block,
             status,
@@ -858,6 +868,7 @@ const handleJobUpdate = (
                     content: truncatedError,
                   } as ContentBlock,
                 ],
+            ...(alreadyAppended ? {} : { jobErrorAppended: true }),
           }
         }
         return { ...block, status }


### PR DESCRIPTION
Agent-block job_update errors now use the explicit jobErrorAppended flag (mirroring the tool-block path) instead of last-text comparison, so a genuinely new identical error is not suppressed when prior output coincidentally matches. The two job-state mappers gained an exhaustiveness assert so a future job-state enum member fails at compile time. Tests: 21 passing, 0 failing in sdk-event-handlers; cli typecheck clean; prior gate review LOOKS_GOOD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/33)
<!-- Reviewable:end -->
