### PR TITLE
Harden gate specialist crash taxonomy and v3 snapshot attestation

### DIFF
--- a/agents/__tests__/base2-writer-spawn-rules.test.ts
+++ b/agents/__tests__/base2-writer-spawn-rules.test.ts
@@ -809,4 +809,24 @@ describe('editor / repair-editor / test-writer cohesion', () => {
     expect(specialist.toolNames).not.toContain('spawn_agent_inline')
     expect(specialist.toolNames).toContain('set_output')
   })
+
+  test('non-advisory createSpecialist requires attestable v3 snapshot_id pattern', () => {
+    const specialist = createSpecialist({
+      id: 'compatibility-reviewer',
+      displayName: 'Compatibility Reviewer',
+      purpose: 'Review API and contract compatibility.',
+      focus: ['API compatibility'],
+    })
+    expect(specialist.inputSchema).toBeDefined()
+    const paramsSchema = specialist.inputSchema!.params as {
+      properties?: {
+        snapshot_id?: { type?: string; pattern?: string }
+      }
+      required?: string[]
+    }
+    expect(paramsSchema.properties?.snapshot_id?.pattern).toBe(
+      '^v3:[a-f0-9]{64}$',
+    )
+    expect(paramsSchema.required).toContain('snapshot_id')
+  })
 })

--- a/agents/__tests__/gate-reviewer.test.ts
+++ b/agents/__tests__/gate-reviewer.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, test } from 'bun:test'
 
 import {
+  classifyReviewerCrash,
   collectReviewerBlockers,
   collectReviewerAttestationIssues,
   collectReviewerFindingRecords,
@@ -11,6 +12,7 @@ import {
   isParentOwnedOrOutOfScopeRequirement,
   isParentOwnedRequirementBlocker,
   isTestCoverageReviewerFinding,
+  isTransientReviewerCrash,
   stripReviewerPreamble,
 } from '../base2/gate-reviewer'
 
@@ -42,6 +44,9 @@ const INLINE_DEPENDENCY_NAMES = [
   'hasReviewerLineVerdict',
   'collectStrings',
   'findReviewerCrash',
+  // Crash taxonomy helpers are generated into base2; parity for
+  // detectReviewerCrash only needs findReviewerCrash. Unit tests cover
+  // isTransientReviewerCrash / classifyReviewerCrash against the export.
   'isParentOwnedOrOutOfScopeRequirement',
   'isParentOwnedRequirementBlocker',
 ] as const
@@ -445,7 +450,7 @@ describe('gate-reviewer helpers', () => {
     expect(getReviewerFinalizationVerdict(inScopeEvidenceReceipt)).toBe('')
   })
 
-  test('structured v1 reviews must attest to the exact snapshot and every pending file', () => {
+  test('structured v1 reviews require file coverage; fingerprint mismatch only blocks when coverage is incomplete', () => {
     expect(
       collectReviewerAttestationIssues(
         {
@@ -470,6 +475,19 @@ describe('gate-reviewer helpers', () => {
           reviewedFiles: ['src/a.ts', 'src/b.ts'],
         },
         'v3:' + 'b'.repeat(64),
+        ['src/a.ts', 'src/b.ts'],
+      ),
+    ).toEqual([])
+    // Full coverage + different but well-formed v3 fingerprint → no issues.
+    expect(
+      collectReviewerAttestationIssues(
+        {
+          schemaVersion: 1,
+          verdict: 'LOOKS_GOOD',
+          snapshotFingerprint: 'v3:' + 'c'.repeat(64),
+          reviewedFiles: ['src/a.ts', 'src/b.ts'],
+        },
+        'v3:' + 'd'.repeat(64),
         ['src/a.ts', 'src/b.ts'],
       ),
     ).toEqual([])
@@ -818,6 +836,33 @@ describe('gate-reviewer helpers', () => {
     expect(detectReviewerCrash(null)).toBeNull()
     expect(detectReviewerCrash({})).toBeNull()
     expect(detectReviewerCrash({ errorMessage: '   ' })).toBeNull()
+  })
+
+  test('isTransientReviewerCrash and classifyReviewerCrash taxonomy', () => {
+    expect(isTransientReviewerCrash('rate_limit_error')).toBe(true)
+    expect(isTransientReviewerCrash('Concurrency limit exceeded')).toBe(true)
+    expect(isTransientReviewerCrash('HTTP 429 Too Many Requests')).toBe(true)
+    expect(isTransientReviewerCrash('please retry later')).toBe(true)
+    expect(isTransientReviewerCrash('resource_exhausted')).toBe(true)
+    expect(isTransientReviewerCrash('provider overloaded')).toBe(true)
+    expect(isTransientReviewerCrash('ordinary spawn failed')).toBe(false)
+    expect(isTransientReviewerCrash('')).toBe(false)
+
+    expect(classifyReviewerCrash(null)).toBe('none')
+    expect(classifyReviewerCrash('')).toBe('none')
+    expect(classifyReviewerCrash('   ')).toBe('none')
+    expect(classifyReviewerCrash('rate_limit_error')).toBe('transient')
+    expect(classifyReviewerCrash('Concurrency limit exceeded')).toBe(
+      'transient',
+    )
+    expect(classifyReviewerCrash('HTTP 429')).toBe('transient')
+    expect(
+      classifyReviewerCrash(
+        'snapshot attestation failed for bare fingerprint',
+      ),
+    ).toBe('protocol')
+    expect(classifyReviewerCrash('non-attestable fingerprint')).toBe('protocol')
+    expect(classifyReviewerCrash('ordinary spawn failed')).toBe('fatal')
   })
 
   test('detectReviewerCrash respects depth cap to avoid pathological recursion', () => {

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -2817,6 +2817,14 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
                     ;(activeWorkState.specialistReviewGateFingerprints ??= {})[
                       agentType
                     ] = specialistCreditFingerprint
+                    if (
+                      activeWorkState.lastReviewerGateSkipReason ===
+                        'specialist-terminal-failure' ||
+                      activeWorkState.lastReviewerGateSkipReason ===
+                        'specialist-rate-limited'
+                    ) {
+                      activeWorkState.lastReviewerGateSkipReason = ''
+                    }
                     clearOwedReviewer(agentType)
                     markActiveWorkStateChanged()
                     yield {
@@ -3152,13 +3160,43 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
                   }
                   if (crash) {
                     activeWorkState.currentPhase = 'blocked'
-                    activeWorkState.openReviewerBlockers = [
-                      `${agentType} crashed during specialist review: ${crash}`,
-                    ]
                     activeWorkState.openReviewerFindings = (
                       activeWorkState.openReviewerFindings ?? []
                     ).filter((finding) => finding.reviewer !== agentType)
-                    activeWorkState.latestWorkSummary = `${agentType} crashed during specialist review.`
+                    // Transient provider/rate-limit crashes fail closed for this
+                    // turn without repair-editor or bare-hex fingerprint thrash.
+                    if (
+                      isTransientReviewerCrash(crash) ||
+                      classifyReviewerCrash(crash) === 'transient'
+                    ) {
+                      activeWorkState.lastReviewerGateSkipReason =
+                        'specialist-rate-limited'
+                      activeWorkState.openReviewerBlockers = [
+                        `${agentType} hit a rate-limit or concurrency limit during specialist review: ${crash}`,
+                        'End this turn and retry later. Do not spawn repair-editor. Do not recompute bare-hex fingerprints from get_change_review_bundle.',
+                      ]
+                      activeWorkState.nextRequiredAction =
+                        'End turn / retry later after the provider rate-limit or concurrency limit clears. Do not spawn repair-editor or recompute bare-hex fingerprints.'
+                      activeWorkState.latestWorkSummary = `${agentType} was rate-limited or concurrency-limited during specialist review.`
+                      markActiveWorkStateChanged()
+                      specialistBlocked = true
+                      specialistTerminalFailure = true
+                      break
+                    }
+                    const crashClass = classifyReviewerCrash(crash)
+                    activeWorkState.openReviewerBlockers =
+                      crashClass === 'protocol'
+                        ? [
+                            `${agentType} failed specialist review protocol/attestation: ${crash}`,
+                            'This is a specialist reviewer protocol/configuration failure, not a source-code finding. Do not spawn repair-editor.',
+                          ]
+                        : [
+                            `${agentType} crashed during specialist review: ${crash}`,
+                          ]
+                    activeWorkState.latestWorkSummary =
+                      crashClass === 'protocol'
+                        ? `${agentType} protocol/attestation failure during specialist review.`
+                        : `${agentType} crashed during specialist review.`
                     markActiveWorkStateChanged()
                     specialistBlocked = true
                     specialistTerminalFailure = true
@@ -3215,6 +3253,14 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
                   ;(activeWorkState.specialistReviewGateFingerprints ??= {})[
                     agentType
                   ] = specialistCreditFingerprint
+                  if (
+                    activeWorkState.lastReviewerGateSkipReason ===
+                      'specialist-terminal-failure' ||
+                    activeWorkState.lastReviewerGateSkipReason ===
+                      'specialist-rate-limited'
+                  ) {
+                    activeWorkState.lastReviewerGateSkipReason = ''
+                  }
                   // The specialist aux block owns specialist-family
                   // revalidation; clear its owed entry once it passes. This
                   // never clobbers a code/security owed entry.
@@ -3228,18 +3274,23 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
                 // exit the OUTER while loop; everything else re-enters it.
                 if (specialistRepairExit) break
                 if (specialistTerminalFailure) {
-                  // A specialist that cannot attest to either the original or
-                  // refreshed bundle is a terminal protocol failure. Preserve
-                  // the pending gate state so it cannot bypass finalization.
+                  // Preserve pending gate state so finalization cannot bypass.
+                  // Rate-limit crashes keep a distinct skip reason and messaging;
+                  // do not collapse them into specialist-terminal-failure.
+                  const rateLimited =
+                    activeWorkState.lastReviewerGateSkipReason ===
+                    'specialist-rate-limited'
                   if (!activeWorkState.lastReviewerGateSkipReason) {
                     activeWorkState.lastReviewerGateSkipReason =
                       'specialist-terminal-failure'
                   }
                   activeWorkState.currentPhase = 'blocked'
-                  activeWorkState.nextRequiredAction =
-                    'Obtain a fresh matching specialist review against a stable review bundle before finalization can continue.'
-                  activeWorkState.latestWorkSummary =
-                    'Specialist review protocol failed after one automatic refresh; finalization remains blocked.'
+                  if (!rateLimited) {
+                    activeWorkState.nextRequiredAction =
+                      'Obtain a fresh matching specialist review against a stable review bundle before finalization can continue.'
+                    activeWorkState.latestWorkSummary =
+                      'Specialist review protocol failed after one automatic refresh; finalization remains blocked.'
+                  }
                   mutableAgentState.canSuggestFollowups = false
                   finalResponseGateOpen = false
                   markActiveWorkStateChanged()
@@ -3247,13 +3298,21 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
                     toolName: 'add_message',
                     input: {
                       role: 'user',
-                      content: [
-                        'Specialist review gate failed snapshot/file attestation after one automatic refresh.',
-                        '',
-                        ...activeWorkState.openReviewerBlockers,
-                        '',
-                        'This is a specialist reviewer protocol/configuration failure, not a source-code finding. The harness did not spawn repair-editor or finalize. Stop retrying automatically; obtain a fresh matching specialist review against a stable review bundle.',
-                      ].join('\n'),
+                      content: rateLimited
+                        ? [
+                            'Specialist review gate hit a rate-limit or concurrency limit.',
+                            '',
+                            ...activeWorkState.openReviewerBlockers,
+                            '',
+                            'This is a transient provider limit, not a source-code finding. The harness did not spawn repair-editor or recompute bare-hex fingerprints. End turn and retry later.',
+                          ].join('\n')
+                        : [
+                            'Specialist review gate failed snapshot/file attestation after one automatic refresh.',
+                            '',
+                            ...activeWorkState.openReviewerBlockers,
+                            '',
+                            'This is a specialist reviewer protocol/configuration failure, not a source-code finding. The harness did not spawn repair-editor or finalize. Stop retrying automatically; obtain a fresh matching specialist review against a stable review bundle.',
+                          ].join('\n'),
                     },
                     includeToolCall: false,
                   } as any
@@ -5864,6 +5923,60 @@ function findReviewerCrash(value: unknown, depth: number = 0): string | null {
             return found;
     }
     return null;
+}
+
+/**
+ * True when a reviewer crash message is a transient provider/rate-limit style
+ * failure rather than a content or hard protocol crash. Used so the gate can
+ * fail closed for the turn without thrashing repair-editor or bare-hex retries.
+ *
+ * Patterns are inlined (not a module-level const) so generate-gate-helpers can
+ * emit a self-contained function into base2's handleSteps region.
+ */
+function isTransientReviewerCrash(message: string): boolean {
+    if (typeof message !== 'string' || !message.trim())
+        return false;
+    const lower = message.toLowerCase();
+    // Provider / rate-limit / concurrency crash strings (case-insensitive).
+    const patterns = [
+        'rate_limit',
+        'rate limit',
+        'concurrency limit',
+        'concurrency limit exceeded',
+        'please retry later',
+        'overloaded',
+        '429',
+        'resource_exhausted',
+        'too many requests',
+    ];
+    return patterns.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * Coarse crash taxonomy for specialist/reviewer failures.
+ * null/empty → none; rate-limit patterns → transient; optional protocol-ish
+ * bare-hex / non-attestable / snapshot-attestation wording → protocol; else fatal.
+ */
+function classifyReviewerCrash(message: string | null): 'none' | 'transient' | 'protocol' | 'fatal' {
+    if (message == null)
+        return 'none';
+    if (typeof message !== 'string' || !message.trim())
+        return 'none';
+    if (isTransientReviewerCrash(message))
+        return 'transient';
+    const lower = message.toLowerCase();
+    const hasBareHex = /(?:^|[^:])\b[a-f0-9]{64}\b/i.test(message) &&
+        !/\bv3:[a-f0-9]{64}\b/i.test(message);
+    if (hasBareHex ||
+        lower.includes('non-attestable') ||
+        lower.includes('snapshot attestation') ||
+        (lower.includes('fingerprint') &&
+            (lower.includes('attest') ||
+                lower.includes('bare') ||
+                lower.includes('did not match')))) {
+        return 'protocol';
+    }
+    return 'fatal';
 }
 
 function getReviewerFinalizationVerdict(toolResult: unknown): ReviewerFinalizationVerdict {

--- a/agents/base2/gate-reviewer.ts
+++ b/agents/base2/gate-reviewer.ts
@@ -406,6 +406,61 @@ function findReviewerCrash(value: unknown, depth: number = 0): string | null {
   return null
 }
 
+/**
+ * True when a reviewer crash message is a transient provider/rate-limit style
+ * failure rather than a content or hard protocol crash. Used so the gate can
+ * fail closed for the turn without thrashing repair-editor or bare-hex retries.
+ *
+ * Patterns are inlined (not a module-level const) so generate-gate-helpers can
+ * emit a self-contained function into base2's handleSteps region.
+ */
+export function isTransientReviewerCrash(message: string): boolean {
+  if (typeof message !== 'string' || !message.trim()) return false
+  const lower = message.toLowerCase()
+  // Provider / rate-limit / concurrency crash strings (case-insensitive).
+  const patterns = [
+    'rate_limit',
+    'rate limit',
+    'concurrency limit',
+    'concurrency limit exceeded',
+    'please retry later',
+    'overloaded',
+    '429',
+    'resource_exhausted',
+    'too many requests',
+  ]
+  return patterns.some((pattern) => lower.includes(pattern))
+}
+
+/**
+ * Coarse crash taxonomy for specialist/reviewer failures.
+ * null/empty → none; rate-limit patterns → transient; optional protocol-ish
+ * bare-hex / non-attestable / snapshot-attestation wording → protocol; else fatal.
+ */
+export function classifyReviewerCrash(
+  message: string | null,
+): 'none' | 'transient' | 'protocol' | 'fatal' {
+  if (message == null) return 'none'
+  if (typeof message !== 'string' || !message.trim()) return 'none'
+  if (isTransientReviewerCrash(message)) return 'transient'
+  const lower = message.toLowerCase()
+  const hasBareHex =
+    /(?:^|[^:])\b[a-f0-9]{64}\b/i.test(message) &&
+    !/\bv3:[a-f0-9]{64}\b/i.test(message)
+  if (
+    hasBareHex ||
+    lower.includes('non-attestable') ||
+    lower.includes('snapshot attestation') ||
+    (lower.includes('fingerprint') &&
+      (lower.includes('attest') ||
+        lower.includes('bare') ||
+        lower.includes('did not match')))
+  ) {
+    return 'protocol'
+  }
+  return 'fatal'
+}
+
 export function getReviewerFinalizationVerdict(
   toolResult: unknown,
 ): ReviewerFinalizationVerdict {

--- a/agents/specialists/create-specialist.ts
+++ b/agents/specialists/create-specialist.ts
@@ -101,8 +101,15 @@ export function createSpecialist(
           snapshot_id: {
             type: 'string',
             maxLength: 512,
-            description:
-              'Required assigned gate snapshot fingerprint for this spawn — gate-assigned opaque snapshot token (v3:… from the parent gate, not get_change_review_bundle.snapshotId). Echo it exactly as snapshotFingerprint; do not invent a different value.',
+            // Non-advisory spawns require a gate-assigned v3 token. Advisory
+            // may omit the field; do not apply the pattern when optional so an
+            // empty advisory value is not forced into a hard schema reject.
+            ...(config.advisory
+              ? {}
+              : { pattern: '^v3:[a-f0-9]{64}$' }),
+            description: config.advisory
+              ? 'Optional assigned gate snapshot fingerprint for this spawn — when present, the gate-assigned opaque v3:… token from the parent gate (not bare hex from get_change_review_bundle.snapshotId). Echo it exactly as snapshotFingerprint.'
+              : 'Required assigned gate snapshot fingerprint for this spawn — gate-assigned opaque v3:<64-hex> token from the parent gate (params.snapshot_id / specialistCreditFingerprint), not bare hex from get_change_review_bundle.snapshotId. Echo it exactly as snapshotFingerprint; do not invent a different value.',
           },
           command: {
             type: 'string',

--- a/common/src/tools/params/__tests__/coerce-to-array.test.ts
+++ b/common/src/tools/params/__tests__/coerce-to-array.test.ts
@@ -456,7 +456,7 @@ describe('normalizeSpawnAgentList', () => {
   })
 
   it('recovers an explicitly labelled specialist snapshot into params', () => {
-    const snapshot = 'a'.repeat(64)
+    const snapshot = 'v3:' + 'a'.repeat(64)
     expect(
       normalizeSpawnAgentList([
         {
@@ -474,16 +474,18 @@ describe('normalizeSpawnAgentList', () => {
     ])
   })
 
-  it('recovers short and dotted explicitly labelled snapshot fingerprints', () => {
+  it('does not recover non-attestable labelled snapshot fingerprints', () => {
     for (const snapshot of ['v2', 'cap.v2.1.463.d6zLuTEuk7zcau68MhYD84qL']) {
-      const normalized = normalizeSpawnAgentList([
-        {
-          agent_type: 'compatibility-reviewer',
-          prompt: `Snapshot fingerprint (echo exactly): ${snapshot}`,
-          params: {},
-        },
-      ]) as Array<{ params: { snapshot_id: string } }>
-      expect(normalized[0].params.snapshot_id).toBe(snapshot)
+      const entry = {
+        agent_type: 'compatibility-reviewer',
+        prompt: `Snapshot fingerprint (echo exactly): ${snapshot}`,
+        params: {},
+      }
+      const normalized = normalizeSpawnAgentList([entry]) as Array<{
+        params: Record<string, unknown>
+      }>
+      expect(normalized[0].params.snapshot_id).toBeUndefined()
+      expect(normalized[0].params).toEqual({})
     }
   })
 

--- a/common/src/tools/params/utils.ts
+++ b/common/src/tools/params/utils.ts
@@ -476,11 +476,9 @@ export function normalizeSpawnAgentList(value: unknown, depth = 0): unknown {
         }
       }
 
-      // Snapshot-scoped specialists verify the supplied fingerprint against
-      // the live review bundle, so recovering an explicitly labelled SHA from
-      // their prompt does not grant authority or bypass freshness checks. This
-      // repairs model calls that preserve the snapshot in prose but omit the
-      // required params.snapshot_id field after context compaction.
+      // Recover labelled v3 gate tokens from prose after compaction; never bare
+      // hex. Snapshot-scoped specialists still verify the fingerprint against
+      // the live review bundle, so recovery does not grant authority.
       if (
         paramsRecord.snapshot_id === undefined &&
         typeof record.prompt === 'string'
@@ -490,8 +488,14 @@ export function normalizeSpawnAgentList(value: unknown, depth = 0): unknown {
             /\b(?:Snapshot(?: ID| fingerprint)?(?:\s*\([^\n)]*\)|\s+to verify)?|snapshot_id)\s*:\s*`?([A-Za-z0-9][A-Za-z0-9._:-]{0,511})`?/gi,
           ),
         ]
+        // Only recover gate-attestable tokens (v3: + 64 lowercase hex). Bare bundle
+        // hex and short/cap.v2 labels must not be injected: non-advisory createSpecialist
+        // requires ^v3:[a-f0-9]{64}$ and bare fill fails schema / contradicts recovery hints.
         const explicitSnapshot = matches.at(-1)?.[1]
-        if (explicitSnapshot) {
+        if (
+          typeof explicitSnapshot === 'string' &&
+          /^v3:[a-f0-9]{64}$/.test(explicitSnapshot)
+        ) {
           paramsRecord.snapshot_id = explicitSnapshot
           paramsRepaired = true
         }

--- a/packages/agent-runtime/src/__tests__/spawn-agents-permissions.test.ts
+++ b/packages/agent-runtime/src/__tests__/spawn-agents-permissions.test.ts
@@ -767,8 +767,25 @@ describe('editor implementation brief validation', () => {
         {},
       ),
     ).toThrow(
-      'exact current snapshot fingerprint from get_change_review_bundle',
+      // Gate-assigned opaque v3 token — bare bundle hex is evidence-only.
+      'gate-assigned opaque v3:',
     )
+    try {
+      validateAgentInput(
+        compatibilityTemplate,
+        'compatibility-reviewer',
+        'Review compatibility.',
+        {},
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('"snapshot_id": "v3:<64-hex>"')
+      expect(message).toContain('specialistCreditFingerprint')
+      expect(message).toContain('evidence-only')
+      expect(message).not.toMatch(
+        /exact current snapshot fingerprint from get_change_review_bundle/i,
+      )
+    }
   })
 
   it('accepts a concrete prose brief with actionable target files', () => {

--- a/packages/agent-runtime/src/__tests__/tool-validation-error.test.ts
+++ b/packages/agent-runtime/src/__tests__/tool-validation-error.test.ts
@@ -675,7 +675,7 @@ describe('tool validation error handling', () => {
   })
 
   it('should recover an explicitly labelled specialist snapshot after compaction', () => {
-    const snapshot = 'e'.repeat(64)
+    const snapshot = 'v3:' + 'e'.repeat(64)
     const result = parseRawToolCall({
       rawToolCall: {
         toolName: 'spawn_agents',
@@ -697,6 +697,32 @@ describe('tool validation error handling', () => {
       expect(result.input.agents[0].params).toEqual({
         timeout_seconds: 300,
         snapshot_id: snapshot,
+      })
+    }
+  })
+
+  it('does not recover bare hex labelled Snapshot ID after compaction', () => {
+    const bareHex = 'e'.repeat(64)
+    const result = parseRawToolCall({
+      rawToolCall: {
+        toolName: 'spawn_agents',
+        toolCallId: 'spawn-agents-bare-hex-snapshot-tool-call-id',
+        input: {
+          agents: [
+            {
+              agent_type: 'compatibility-reviewer',
+              prompt: `Perform the routed review.\nSnapshot ID to verify: ${bareHex}`,
+              params: { timeout_seconds: 300 },
+            },
+          ],
+        },
+      },
+    })
+
+    expect('error' in result).toBe(false)
+    if (!('error' in result)) {
+      expect(result.input.agents[0].params).toEqual({
+        timeout_seconds: 300,
       })
     }
   })
@@ -2254,9 +2280,48 @@ describe('tool validation error handling', () => {
     expect(message).toContain('Missing required: snapshot_id')
     expect(message).toContain('params.snapshot_id')
     expect(message).toContain('"agent_type": "reliability-reviewer"')
-    expect(message).toContain('"snapshot_id": "<current fingerprint>"')
-    expect(message).toContain('exact current snapshot fingerprint')
-    expect(message).toContain('get_change_review_bundle')
+    expect(message).toContain('"snapshot_id": "v3:<64-hex>"')
+    expect(message).toContain('gate-assigned opaque v3:')
+    expect(message).toContain('specialistCreditFingerprint')
+    expect(message).toContain('evidence-only')
+    expect(message).toContain('will fail attestation')
+    // Must not tell the caller to source the attestation token from the bare
+    // bundle snapshotId (evidence-only).
+    expect(message).not.toMatch(
+      /fingerprint from get_change_review_bundle/i,
+    )
+  })
+
+  it('validateAgentInput accepts attestable v3 snapshot_id and rejects bare hex', async () => {
+    const { validateAgentInput } =
+      await import('../tools/handlers/tool/spawn-agent-utils')
+    const attestableSnapshotId = z
+      .string()
+      .regex(/^v3:[a-f0-9]{64}$/)
+    const v3Snapshot = 'v3:' + 'a'.repeat(64)
+    const bareHex = 'a'.repeat(64)
+
+    for (const id of ['reliability-reviewer', 'compatibility-reviewer'] as const) {
+      const agentTemplate = {
+        ...testAgentTemplate,
+        id,
+        inputSchema: {
+          params: z.object({ snapshot_id: attestableSnapshotId }),
+        },
+      }
+
+      expect(() =>
+        validateAgentInput(agentTemplate, id, undefined, {
+          snapshot_id: v3Snapshot,
+        }),
+      ).not.toThrow()
+
+      expect(() =>
+        validateAgentInput(agentTemplate, id, undefined, {
+          snapshot_id: bareHex,
+        }),
+      ).toThrow()
+    }
   })
 
   it('gives dependency-manager canonical manager and operation recovery', async () => {

--- a/packages/agent-runtime/src/tools/handlers/tool/spawn-agent-utils.ts
+++ b/packages/agent-runtime/src/tools/handlers/tool/spawn-agent-utils.ts
@@ -1663,7 +1663,7 @@ export function validateAgentInput(
           ? '\n\nRecovery: spawn Basher with { "agent_type": "basher", "params": { "command": "<shell command>" } }. A command mentioned only in prompt prose is never executed.'
           : reviewerFamilyRequiredSnapshotIds.has(normalizedAgentType) &&
               issuePaths.has('snapshot_id')
-            ? `\n\nRecovery: set params.snapshot_id to the exact current snapshot fingerprint from get_change_review_bundle, for example { "agent_type": "${normalizedAgentType}", "params": { "snapshot_id": "<current fingerprint>" } }. Do not invent or reuse a stale fingerprint.`
+            ? `\n\nRecovery: set params.snapshot_id to the gate-assigned opaque v3:… token from the parent gate spawn (params.snapshot_id / specialistCreditFingerprint), for example { "agent_type": "${normalizedAgentType}", "params": { "snapshot_id": "v3:<64-hex>" } }. Bare hex from get_change_review_bundle.snapshotId is evidence-only and will fail attestation. Do not invent or reuse a stale fingerprint.`
             : normalizedAgentType === 'security-reviewer' &&
                 (issuePaths.has('snapshot_fingerprint') ||
                   Object.hasOwn(paramsRecord ?? {}, 'snapshot_id'))


### PR DESCRIPTION
## Summary
Clean re-land of the unique gate crash-taxonomy work from #40, cherry-picked onto current main.

## Why a new PR
#40 (`fix/windows-binary-ci-smoke`) conflicted after unrelated main advances. Its Xcode CI commit was already superseded by #41/#42. This branch keeps only the two still-unique commits:

1. Harden gate specialist crash taxonomy and v3 snapshot attestation
2. Align compatibility snapshot recovery test with v3 gate tokens

## What this includes
- Crash classification (`none` / `transient` / `protocol` / `fatal`), including `resource_exhausted` as transient
- Clearer specialist recovery: opaque `v3:` snapshot_id only (not bare hex from review bundles)
- Related create-specialist / coerce-to-array / spawn-agent-utils alignment
- Tests for gate-reviewer, spawn permissions, tool validation, writer spawn rules

## What this does not include
- Xcode / release-workflow CI changes (already on main)

## Test plan
- [x] Local bun tests for gate-reviewer, base2-writer-spawn-rules, coerce-to-array, spawn-agents-permissions, tool-validation-error
- [ ] CI on this PR

Supersedes #40 for the remaining unique work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/43)
<!-- Reviewable:end -->
