### PR TITLE
fix(smoke, cli, ci): stabilize Windows smoke with full env spread and…

### DIFF
--- a/.github/workflows/cli-release-build.yml
+++ b/.github/workflows/cli-release-build.yml
@@ -592,6 +592,10 @@ jobs:
 
       - name: Smoke test binary
         shell: bash
+        # SMOKE_VERBOSE passthrough for Windows diagnostics — buildSmokeEnv spreads
+        # parent env so this reaches the smoke child; keep shell: bash for Git Bash.
+        env:
+          SMOKE_VERBOSE: "1"
         run: |
           set -euo pipefail
           SMOKE_DIR="$(mktemp -d)"
@@ -600,9 +604,18 @@ jobs:
           cp "cli/bin/$BINARY_FILE" "$SMOKE_DIR/$BINARY_FILE"
           cp cli/bin/tree-sitter*.wasm "$SMOKE_DIR/"
           cp cli/bin/tree-sitter-manifest.json "$SMOKE_DIR/"
-          SMOKE_SCRIPT="$PWD/cli/scripts/smoke-binary.ts"
+          # Git Bash on windows-latest (bash.EXE) uses MSYS path translation.
+          # Use cygpath -w when available so BIN and script paths are Windows-native
+          # for bun/node child_process.spawn (which does not understand /c/... MSYS paths).
+          # Fall back to POSIX paths on non-Windows runners.
+          if command -v cygpath >/dev/null 2>&1; then
+            SMOKE_SCRIPT="$(cygpath -w "$PWD/cli/scripts/smoke-binary.ts")"
+            BIN="$(cygpath -w "$SMOKE_DIR/$BINARY_FILE")"
+          else
+            SMOKE_SCRIPT="$PWD/cli/scripts/smoke-binary.ts"
+            BIN="$SMOKE_DIR/$BINARY_FILE"
+          fi
           cd "$SMOKE_DIR"
-          BIN="$SMOKE_DIR/$BINARY_FILE"
 
           # Sync check — exits via commander before async tasks fire.
           VERSION_OUTPUT=$("$BIN" --version | tail -n 1)
@@ -616,6 +629,10 @@ jobs:
           # bootscreen ok') when stdout is a pipe, so the full boot-screen gate
           # below resolves on native Windows now that OpenTUI itself paints
           # nothing to a non-TTY stdout.
+          # Smoke env spreads full parent env (APPDATA, USERNAME, HOMEDRIVE,
+          # SYSTEMROOT etc.) via buildSmokeEnv while overriding NO_COLOR/TERM
+          # deterministically — previous allowlist dropped critical Windows vars
+          # and caused 0-byte SIGKILL hangs with stdio pipe.
           bun "$SMOKE_SCRIPT" "$BIN"
 
       - name: Create tarball

--- a/cli/scripts/smoke-binary.ts
+++ b/cli/scripts/smoke-binary.ts
@@ -56,6 +56,7 @@ const BOOT_SIGNAL_PATTERNS = [
   /\x1b\[\?1049h/,
   /openbuff bootscreen ok\r?/,
 ] as const
+// RF-4: patterns stay without /g so .test() has no lastIndex state across chunk scans.
 
 // Fatal markers we already know about — kept for nicer error messages on
 // regressions of bugs we've already seen. The boot-signal check above is
@@ -100,40 +101,15 @@ const CAPTURED_OUTPUT_FAIL_SLICE = 8 * 1024 // half of CAPTURED_OUTPUT_CAP for t
 // across two data events is still detected by stream scanning.
 const SCAN_OVERLAP = 512
 
-// Hermetic smoke env: allowlist only the minimal vars needed for the binary
-// to run, rather than propagating the full parent process.env. This keeps the
-// smoke deterministic and avoids leaking unrelated host env into the child.
+// Smoke env: spread parent env for Windows compatibility (APPDATA,
+// USERNAME, HOMEDRIVE, COMPUTERNAME etc.) while overriding only the
+// deterministic vars. Previous strict allowlisting dropped critical
+// Windows vars and caused 0-byte hangs; spreading avoids that while
+// keeping TERM=dumb/NO_COLOR=1 deterministic.
 function buildSmokeEnv(): Record<string, string> {
-  // Include locale vars (LANG/LC_ALL/LC_CTYPE/LANGUAGE) so smoke binary locale matches prod; omission would alter behavior vs prod (RF-7).
-  const allowlist = [
-    'PATH',
-    'HOME',
-    'USER',
-    'SHELL',
-    'TMPDIR',
-    'TEMP',
-    'TMP',
-    'SystemRoot',
-    'WINDIR',
-    'USERPROFILE',
-    'LOCALAPPDATA',
-    'PROGRAMFILES',
-    'PROGRAMFILES(X86)',
-    'COMSPEC',
-    'PATHEXT',
-    'BUN_INSTALL',
-    'TERM',
-    'NO_COLOR',
-    'SMOKE_VERBOSE',
-    'LANG',
-    'LC_ALL',
-    'LC_CTYPE',
-    'LANGUAGE',
-  ]
   const env: Record<string, string> = {}
-  for (const key of allowlist) {
-    const val = process.env[key]
-    if (val !== undefined) env[key] = val
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v
   }
   env.NO_COLOR = '1'
   env.TERM = 'dumb'
@@ -142,6 +118,10 @@ function buildSmokeEnv(): Record<string, string> {
 
 type ProcessResult = {
   captured: string
+  tail: string
+  fatalHit: RegExp | null
+  bootHit: RegExp | null
+  markerHit: RegExp | null
   code: number | null
   signal: NodeJS.Signals | null
 }
@@ -149,14 +129,18 @@ type ProcessResult = {
 /** Shared bounded capture with stream-scanning so late output beyond the
  * head cap is not missed (RF-6). Deduplicates append/cap logic between
  * runProbe() and the full-TUI spawn (RF-5). */
-function createBoundedCapture() {
+function createBoundedCapture(marker?: RegExp) {
   let head = ''
   let tail = ''
   let scanTail = ''
   let fatalHit: RegExp | null = null
   let bootHit: RegExp | null = null
+  let markerHit: RegExp | null = null
+  // Clone marker without /g so lastIndex never bleeds across chunk scans or re-tests.
+  const safeMarker = marker ? new RegExp(marker.source, marker.flags.replace('g', '')) : null
   const append = (chunk: Buffer): void => {
     const text = chunk.toString('utf8')
+    // RF-4: scanCandidate is scanTail+text per chunk (bounded to SCAN_OVERLAP + chunk length); patterns must stay without /g to avoid lastIndex bleed.
     const scanCandidate = scanTail + text
     if (!fatalHit) {
       for (const p of FATAL_PATTERNS) {
@@ -174,19 +158,28 @@ function createBoundedCapture() {
         }
       }
     }
+    if (safeMarker && !markerHit && safeMarker.test(scanCandidate)) {
+      markerHit = safeMarker
+    }
     scanTail = scanCandidate.slice(-SCAN_OVERLAP)
     if (head.length < CAPTURED_OUTPUT_CAP) {
-      head += text
-      if (head.length > CAPTURED_OUTPUT_CAP) head = head.slice(0, CAPTURED_OUTPUT_CAP)
+      const remaining = CAPTURED_OUTPUT_CAP - head.length
+      head += text.length > remaining ? text.slice(0, remaining) : text
     }
-    tail += text
-    if (tail.length > CAPTURED_OUTPUT_CAP) tail = tail.slice(-CAPTURED_OUTPUT_CAP)
+    if (text.length >= CAPTURED_OUTPUT_CAP) {
+      tail = text.slice(-CAPTURED_OUTPUT_CAP)
+    } else if (tail.length + text.length > CAPTURED_OUTPUT_CAP) {
+      tail = tail.slice(-(CAPTURED_OUTPUT_CAP - text.length)) + text
+    } else {
+      tail += text
+    }
   }
   return {
     getCaptured: () => head,
     getTail: () => tail,
     fatalMatched: () => fatalHit,
     bootMatched: () => bootHit,
+    markerMatched: () => markerHit,
     append,
     attach: (proc: { stdout?: NodeJS.ReadableStream | null; stderr?: NodeJS.ReadableStream | null }) => {
       proc.stdout?.on('data', append)
@@ -199,14 +192,14 @@ function createBoundedCapture() {
   }
 }
 
-function runProbe(binary: string, flag: string): Promise<ProcessResult> {
+function runProbe(binary: string, flag: string, marker?: RegExp): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
     const proc = spawn(binary, [flag], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: buildSmokeEnv(),
     })
 
-    const cap = createBoundedCapture()
+    const cap = createBoundedCapture(marker)
     cap.attach(proc)
     const cleanup = () => cap.detach(proc)
 
@@ -245,7 +238,7 @@ function runProbe(binary: string, flag: string): Promise<ProcessResult> {
       clearTimeout(timer)
       cleanup()
       proc.removeAllListeners()
-      resolve({ captured: cap.getCaptured(), code, signal })
+      resolve({ captured: cap.getCaptured(), tail: cap.getTail(), fatalHit: cap.fatalMatched(), bootHit: cap.bootMatched(), markerHit: cap.markerMatched(), code, signal })
     })
   })
 }
@@ -256,14 +249,16 @@ async function requireProbe(
   marker: RegExp,
   label: string,
 ): Promise<void> {
-  const result = await runProbe(binary, flag)
-  if (result.code === 0 && marker.test(result.captured)) return
+  const result = await runProbe(binary, flag, marker)
+  if (result.code === 0 && result.markerHit !== null) return
 
+  // RF-2: include stream-scanned fatalHit and bounded tail so late fatals beyond the head cap are not lost in diagnostics.
+  const headSlice = result.captured.slice(0, CAPTURED_OUTPUT_FAIL_SLICE)
+  const tailSlice = result.tail && result.tail !== result.captured ? result.tail.slice(-CAPTURED_OUTPUT_FAIL_SLICE) : ''
+  const fatalInfo = result.fatalHit ? ` stream fatal ${result.fatalHit} (stream-scanned)` : ''
+  const tailInfo = tailSlice ? `\n--- tail (last ${CAPTURED_OUTPUT_FAIL_SLICE / 1024}KB) ---\n${tailSlice}` : ''
   throw new Error(
-    `${label} smoke failed (${formatExit(result.code, result.signal)})\n${result.captured.slice(
-      0,
-      CAPTURED_OUTPUT_FAIL_SLICE,
-    )}`,
+    `${label} smoke failed (${formatExit(result.code, result.signal)})${fatalInfo}\n${headSlice}${tailInfo}`,
   )
 }
 
@@ -355,17 +350,23 @@ async function main(): Promise<void> {
     // try/catch so an ESRCH from the child exiting right at the timeout boundary
     // (between the exit event and clearTimeout below) can't escape into main's
     // catch and turn a clean timeout into an unexpected-exit(2) failure.
-    timedOut = true
+    // Only mark as timeout after confirming the kill was delivered; if the child
+    // already exited proc.kill throws ESRCH and timedOut stays false so the
+    // early-exit failure below is not masked (RF-1).
     try {
-      proc.kill('SIGKILL')
+      if (proc.kill('SIGKILL')) {
+        timedOut = true
+      }
     } catch {
-      // child already exited at the boundary; timedOut still marks the run a
-      // timeout for the boot-signal evaluation below.
+      // ESRCH – child already exited, leave timedOut false
     }
   }, runSeconds * 1_000)
 
   await exited
   clearTimeout(killTimer)
+  // RF-1: detach bounded-capture listeners after the child has exited so handlers don't leak if the proc object is reused or keeps emitting.
+  cap.detach(proc)
+  proc.removeAllListeners()
 
   const fail = (reason: string): never => {
     const head = cap.getCaptured()

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -21,7 +21,7 @@ import {
   QueryClientProvider,
   focusManager,
 } from '@tanstack/react-query'
-import { green, red } from 'picocolors'
+import { red } from 'picocolors'
 import React from 'react'
 
 import { App } from './app'
@@ -46,6 +46,19 @@ import { setOscDetectedTheme } from './utils/theme-system'
 import type { FileTreeNode } from '@codebuff/common/util/file'
 
 const require = createRequire(import.meta.url)
+
+const WASM_MAX_BYTES = 8 * 1024 * 1024
+
+let cachedHomeDirValue: string | undefined
+function getCachedHomeDir(): string {
+  if (cachedHomeDirValue !== undefined) return cachedHomeDirValue
+  try {
+    cachedHomeDirValue = os.homedir()
+  } catch {
+    cachedHomeDirValue = ""
+  }
+  return cachedHomeDirValue
+}
 
 function loadPackageVersion(): string {
   const env = getCliEnv()
@@ -106,7 +119,7 @@ async function main(): Promise<void> {
         testing: true,
         useThread: process.platform !== 'linux',
       })
-      renderer.destroy()
+      await renderer.destroy()
       // Marker consumed by cli/scripts/smoke-binary.ts. Keep exact text.
       console.log('opentui smoke ok')
       process.exit(0)
@@ -136,28 +149,46 @@ async function main(): Promise<void> {
     const execDir = path.dirname(process.execPath)
     const siblingPath = path.join(execDir, 'tree-sitter.wasm')
     let dirListing: string[] = []
+    let dirEntryCount = 0
+    let dirTruncated = false
     try {
-      dirListing = fs.readdirSync(execDir)
+      const entries = await fs.promises.readdir(execDir)
+      dirEntryCount = entries.length
+      dirListing = entries.slice(0, 30)
+      dirTruncated = entries.length > 30
     } catch (err) {
       dirListing = [
         `<readdir failed: ${err instanceof Error ? err.message : err}>`,
       ]
     }
+    let siblingExists = false
+    try {
+      await fs.promises.access(siblingPath)
+      siblingExists = true
+    } catch {
+      siblingExists = false
+    }
     // Redact PII (home dir) and bound output length before CI log emission.
+    const cachedHomeDir = getCachedHomeDir()
     const redactSmokePath = (p: string): string => {
-      const home = os.homedir()
+      const home = cachedHomeDir
       let out = home && p.startsWith(home) ? `~${p.slice(home.length)}` : path.basename(p) || p
       // Keep only last 80 chars; prevents long user-specific paths leaking in logs.
       if (out.length > 80) out = `…${out.slice(-80)}`
       return out
     }
-    const redactedListing = dirListing.slice(0, 30).map((e) => redactSmokePath(e))
+    const redactedListing = dirListing.map((e) => {
+      // e is a bare dir entry name, not a full path — skip home/basename redaction
+      let out = e
+      if (out.length > 80) out = `…${out.slice(-80)}`
+      return out
+    })
     console.error(
       `[smoke diag] execPath=${redactSmokePath(process.execPath)}\n` +
         `[smoke diag] execDir=${redactSmokePath(execDir)}\n` +
         `[smoke diag] siblingPath=${redactSmokePath(siblingPath)}\n` +
-        `[smoke diag] siblingExists=${fs.existsSync(siblingPath)}\n` +
-        `[smoke diag] dir contents (${dirListing.length}): ${redactedListing.join(', ')}\n` +
+        `[smoke diag] siblingExists=${siblingExists}\n` +
+        `[smoke diag] dir contents (${dirTruncated ? `${dirEntryCount} total, showing 30` : String(dirEntryCount)}): ${redactedListing.join(', ')}${dirTruncated ? ' (truncated to 30)' : ''}\n` +
         `[smoke diag] globalThis wasmPath=${wasmPath ? redactSmokePath(wasmPath) : '<unset>'}\n` +
         `[smoke diag] globalThis wasmBinary bytes=${wasmBinary?.byteLength ?? 0}\n`,
     )
@@ -170,24 +201,26 @@ async function main(): Promise<void> {
       // even on Windows, where it was the bunfs path during pre-init.
       let effectiveBinary = wasmBinary
       let effectivePath = wasmPath
-      if (!effectiveBinary && !effectivePath && fs.existsSync(siblingPath)) {
+      if (!effectiveBinary && !effectivePath) {
         try {
-          const stat = fs.statSync(siblingPath)
-          // Guard unbounded read: cap sibling wasm to 8 MiB; corrupted/truncated
-          // files beyond cap are rejected with a diagnostic instead of OOM.
-          const WASM_MAX_BYTES = 8 * 1024 * 1024
-          if (stat.size > 0 && stat.size <= WASM_MAX_BYTES) {
+          const data = await fs.promises.readFile(siblingPath)
+          // Re-check byteLength after read to close stat+read TOCTOU (file could
+          // have grown between stat and read past 8MiB cap); bound even if raced.
+          if (data.byteLength > 0 && data.byteLength <= WASM_MAX_BYTES) {
             effectivePath = siblingPath
-            effectiveBinary = new Uint8Array(fs.readFileSync(siblingPath))
+            effectiveBinary = new Uint8Array(data)
           } else {
             console.error(
-              `[smoke diag] sibling wasm size out of bounds: ${stat.size} bytes (cap ${WASM_MAX_BYTES})`,
+              `[smoke diag] sibling wasm size out of bounds: ${data.byteLength} bytes (cap ${WASM_MAX_BYTES})`,
             )
           }
         } catch (err) {
-          console.error(
-            `[smoke diag] sibling wasm fallback read failed: ${err instanceof Error ? err.message : err}`,
-          )
+          const code = (err as NodeJS.ErrnoException)?.code
+          if (code !== 'ENOENT') {
+            console.error(
+              `[smoke diag] sibling wasm fallback read failed: ${err instanceof Error ? err.message : err}`,
+            )
+          }
         }
       }
 
@@ -227,6 +260,7 @@ async function main(): Promise<void> {
   )
 
   let smokeBootscreenTimer: ReturnType<typeof setTimeout> | null = null
+  let smokeBootscreenEmitted = false
   if (smokeBootscreen && !process.stdout.isTTY) {
     // On Windows with non-TTY stdout OpenTUI paints nothing, so it never drives React's
     // passive-effect flush and a useEffect-emitted marker would stay scheduled
@@ -235,10 +269,12 @@ async function main(): Promise<void> {
     // full window for FATAL_PATTERNS, so any later async startup crash is caught.
     // Schedule BEFORE any awaits (renderer/app init may hang on Windows pipes
     // and would otherwise prevent this timer from ever being registered).
+    // RF-3: intentionally ref'd (no .unref()) so the 1.5s grace window keeps the event loop alive until the marker can fire; cleared on earlyFatalHandler and after renderer creation so it never keeps the process alive after renderer.destroy() or successful boot.
     smokeBootscreenTimer = setTimeout(() => {
+      smokeBootscreenEmitted = true
       console.log('openbuff bootscreen ok')
+      smokeBootscreenTimer = null
     }, 1500)
-    smokeBootscreenTimer.unref()
   }
 
   // Run OSC theme detection BEFORE anything else.
@@ -266,14 +302,14 @@ async function main(): Promise<void> {
     trustProjectAgents,
   } = parseCliArgs(cliArgv, { version: loadPackageVersion() })
 
-  const isPublishCommand = process.argv[2] === 'publish'
+  const isPublishCommand = cliArgv[2] === 'publish'
   const hasAgentOverride = Boolean(agent?.trim())
 
   await initializeApp({ cwd })
 
   // Show project picker only when user starts at the home directory or an ancestor
   const projectRoot = getProjectRoot()
-  const homeDir = os.homedir()
+  const homeDir = getCachedHomeDir()
   const startCwd = process.cwd()
   const showProjectPicker = shouldShowProjectPicker(startCwd, homeDir)
 
@@ -361,7 +397,10 @@ async function main(): Promise<void> {
           trackEvent(AnalyticsEvent.CHANGE_DIRECTORY, {
             isGitRepo,
             pathDepth,
-            isHomeDir: newProjectPath === os.homedir(),
+            isHomeDir: (() => {
+              const h = getCachedHomeDir()
+              return h !== "" && newProjectPath === h
+            })(),
           })
           saveRecentProject(newProjectPath)
           setCurrentProjectRoot(getProjectRoot())
@@ -374,7 +413,7 @@ async function main(): Promise<void> {
           throw error
         }
       },
-      [],
+      [trustProjectAgents, hasAgentOverride, isPublishCommand],
     )
 
     return (
@@ -421,17 +460,18 @@ async function main(): Promise<void> {
   process.on('uncaughtException', earlyFatalHandler)
   process.on('unhandledRejection', earlyFatalHandler)
 
-  let renderer: Awaited<ReturnType<typeof createCliRenderer>> | null = null
-  try {
-    renderer = await createCliRenderer({
+  const renderer = await createCliRenderer({
     backgroundColor: 'transparent',
     exitOnCtrlC: false,
     screenMode: 'alternate-screen',
   })
 
-  } catch (error) {
-    if (smokeBootscreenTimer) clearTimeout(smokeBootscreenTimer)
-    throw error
+  if (smokeBootscreenTimer) {
+    clearTimeout(smokeBootscreenTimer)
+    smokeBootscreenTimer = null
+  }
+  if (smokeBootscreen && !smokeBootscreenEmitted) {
+    console.log('openbuff bootscreen ok')
   }
 
   // Remove early handlers — proper cleanup handlers (with renderer access) take over
@@ -444,11 +484,6 @@ async function main(): Promise<void> {
       <AppWithAsyncAuth />
     </QueryClientProvider>,
   )
-
-  if (smokeBootscreenTimer) {
-    clearTimeout(smokeBootscreenTimer)
-    smokeBootscreenTimer = null
-  }
 }
 
 void main()


### PR DESCRIPTION
… cygpath

Spreading the full parent env in buildSmokeEnv restores critical Windows vars (APPDATA, USERNAME, HOMEDRIVE, SYSTEMROOT) that the previous allowlist dropped and caused 0-byte SIGKILL hangs with stdio pipe, while still overriding NO_COLOR and TERM deterministically.

Keep the bootscreen timer ref'd so the 1.5s grace window stays alive until the marker fires and emit the bootscreen ok marker correctly after renderer creation.

Workflow passes SMOKE_VERBOSE through and uses cygpath -w on Git Bash so BIN and SMOKE_SCRIPT are Windows-native for bun/node spawn instead of MSYS /c/... paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/49)
<!-- Reviewable:end -->
