### PR TITLE
fix(base2,cli): restore programmatic tools and reclaim oversized logs

### DIFF
--- a/agents/__tests__/base2-progressive-tool-disclosure.test.ts
+++ b/agents/__tests__/base2-progressive-tool-disclosure.test.ts
@@ -47,6 +47,10 @@ const PROGRAMMATIC_TOOL_NAMES = [
   'git_status',
   'run_file_change_hooks',
   'inspect_codebase_structure',
+  'get_change_review_bundle',
+  'inspect_environment',
+  'get_affected_tests',
+  'get_build_targets',
 ] as const
 
 const CORE_ALWAYS = [

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -211,6 +211,10 @@ export function createBase2(
       'git_status',
       'run_file_change_hooks',
       'inspect_codebase_structure',
+      'get_change_review_bundle',
+      'inspect_environment',
+      'get_affected_tests',
+      'get_build_targets',
     ],
     spawnableAgentToolMode: 'generic',
     programmaticConfig: {

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -32,7 +32,11 @@ import { trackEvent } from './utils/analytics'
 import { resetCodebuffClient } from './utils/codebuff-client'
 import { getCliEnv } from './utils/env'
 import { initializeAgentRegistry } from './utils/local-agent-registry'
-import { clearLogFile, logger } from './utils/logger'
+import {
+  clearLogFile,
+  logger,
+  trimOversizedLogsOnStartup,
+} from './utils/logger'
 import { shouldShowProjectPicker } from './utils/project-picker'
 import { saveRecentProject } from './utils/recent-projects'
 import {
@@ -306,6 +310,9 @@ async function main(): Promise<void> {
   const hasAgentOverride = Boolean(agent?.trim())
 
   await initializeApp({ cwd })
+
+  // Reclaim any oversized per-chat log left by a previous session.
+  trimOversizedLogsOnStartup()
 
   // Show project picker only when user starts at the home directory or an ancestor
   const projectRoot = getProjectRoot()

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -1,4 +1,11 @@
-import { appendFileSync, existsSync, mkdirSync, unlinkSync } from 'fs'
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'fs'
 import path, { dirname } from 'path'
 import { format as stringFormat } from 'util'
 
@@ -37,6 +44,10 @@ let pinoLogger: any = undefined
 
 const loggingLevels = ['info', 'debug', 'warn', 'error', 'fatal'] as const
 type LogLevel = (typeof loggingLevels)[number]
+
+// Cap log files at 10 MiB. When a log reaches this size we rotate it to a
+// `.1` sibling so `log.jsonl` (and dev `debug/cli.jsonl`) cannot grow unbounded.
+const LOG_MAX_BYTES = 10 * 1024 * 1024
 const analyticsDispatcher = createAnalyticsDispatcher({
   envName: env.NEXT_PUBLIC_CB_ENVIRONMENT,
   bufferWhenNoUser: true,
@@ -95,6 +106,44 @@ function setLogPath(p: string): void {
   )
 }
 
+/**
+ * Rotate a log file to a `.1` sibling once it reaches LOG_MAX_BYTES.
+ * Keeps exactly one prior rotated file: unlink any existing `.1`, then rename.
+ * All fs operations are swallowed so logging never throws.
+ */
+function rotateLogIfNeeded(targetLogPath: string): void {
+  try {
+    if (!existsSync(targetLogPath)) return
+    if (statSync(targetLogPath).size < LOG_MAX_BYTES) return
+
+    const rotatedPath = `${targetLogPath}.1`
+    try {
+      if (existsSync(rotatedPath)) {
+        unlinkSync(rotatedPath)
+      }
+    } catch {
+      // Ignore unlink errors; rename may still fail harmlessly below
+    }
+    renameSync(targetLogPath, rotatedPath)
+  } catch {
+    // Ignore rotation errors; logging must never throw
+  }
+}
+
+/**
+ * One-off cleanup on startup that reclaims an oversized production per-chat
+ * `log.jsonl` by rotating it (not deleting it). Runs automatically after app
+ * initialization, independent of the `--clear-logs` flag.
+ */
+export function trimOversizedLogsOnStartup(): void {
+  try {
+    const productionLog = path.join(getCurrentChatDir(), 'log.jsonl')
+    rotateLogIfNeeded(productionLog)
+  } catch {
+    // Ignore errors resolving the chat dir; logging must never throw
+  }
+}
+
 export function clearLogFile(): void {
   const projectRoot = getProjectRoot()
   const defaultLog = path.join(projectRoot, 'debug', 'cli.jsonl')
@@ -113,6 +162,23 @@ export function clearLogFile(): void {
     } catch {
       // Ignore errors when clearing logs
     }
+  }
+
+  // Also reclaim the production per-chat log: delete the `.1` sibling and,
+  // instead of always deleting the live file, only rotate it when oversized.
+  try {
+    const productionLog = path.join(getCurrentChatDir(), 'log.jsonl')
+    const rotatedLog = `${productionLog}.1`
+    try {
+      if (existsSync(rotatedLog)) {
+        unlinkSync(rotatedLog)
+      }
+    } catch {
+      // Ignore unlink errors
+    }
+    rotateLogIfNeeded(productionLog)
+  } catch {
+    // Ignore errors resolving the chat dir
   }
 
   logPath = undefined
@@ -209,6 +275,7 @@ function sendAnalyticsAndLog(
       ...(includeData ? { data: sanitizedData } : {}),
       msg: formattedMsg,
     })
+    rotateLogIfNeeded(logPath)
     try {
       appendFileSync(logPath, logEntry + '\n')
     } catch {


### PR DESCRIPTION
Allowlist handleSteps audit/implement tools (get_change_review_bundle, inspect_environment, get_affected_tests, get_build_targets) so progressive disclosure no longer blocks specialist gate; rotate per-chat logs at 10 MiB on write and startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/50)
<!-- Reviewable:end -->
