### PR TITLE
fix(cli, logger): cap logs at 10 MiB with rotation and safe fd close

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -32,11 +32,7 @@ import { trackEvent } from './utils/analytics'
 import { resetCodebuffClient } from './utils/codebuff-client'
 import { getCliEnv } from './utils/env'
 import { initializeAgentRegistry } from './utils/local-agent-registry'
-import {
-  clearLogFile,
-  logger,
-  trimOversizedLogsOnStartup,
-} from './utils/logger'
+import { clearLogFile, logger } from './utils/logger'
 import { shouldShowProjectPicker } from './utils/project-picker'
 import { saveRecentProject } from './utils/recent-projects'
 import {
@@ -207,16 +203,27 @@ async function main(): Promise<void> {
       let effectivePath = wasmPath
       if (!effectiveBinary && !effectivePath) {
         try {
-          const data = await fs.promises.readFile(siblingPath)
-          // Re-check byteLength after read to close stat+read TOCTOU (file could
-          // have grown between stat and read past 8MiB cap); bound even if raced.
-          if (data.byteLength > 0 && data.byteLength <= WASM_MAX_BYTES) {
-            effectivePath = siblingPath
-            effectiveBinary = new Uint8Array(data)
-          } else {
+          const siblingStat = await fs.promises.stat(siblingPath)
+          if (
+            !siblingStat.isFile() ||
+            siblingStat.size <= 0 ||
+            siblingStat.size > WASM_MAX_BYTES
+          ) {
             console.error(
-              `[smoke diag] sibling wasm size out of bounds: ${data.byteLength} bytes (cap ${WASM_MAX_BYTES})`,
+              `[smoke diag] sibling wasm size out of bounds: ${siblingStat.size} bytes (cap ${WASM_MAX_BYTES})`,
             )
+          } else {
+            const data = await fs.promises.readFile(siblingPath)
+            // Re-check byteLength after read to close stat+read TOCTOU (file could
+            // have grown between stat and read past 8MiB cap); bound even if raced.
+            if (data.byteLength > 0 && data.byteLength <= WASM_MAX_BYTES) {
+              effectivePath = siblingPath
+              effectiveBinary = new Uint8Array(data)
+            } else {
+              console.error(
+                `[smoke diag] sibling wasm size out of bounds: ${data.byteLength} bytes (cap ${WASM_MAX_BYTES})`,
+              )
+            }
           }
         } catch (err) {
           const code = (err as NodeJS.ErrnoException)?.code
@@ -239,7 +246,9 @@ async function main(): Promise<void> {
           locateFile: (name: string) =>
             name === 'tree-sitter.wasm' ? effectivePath! : name,
         })
-        console.log(`tree-sitter smoke ok (locateFile, path=${effectivePath})`)
+        console.log(
+          `tree-sitter smoke ok (locateFile, path=${redactSmokePath(effectivePath)})`,
+        )
       } else {
         console.error(
           'tree-sitter smoke FAIL: no wasm available — pre-init published ' +
@@ -310,9 +319,6 @@ async function main(): Promise<void> {
   const hasAgentOverride = Boolean(agent?.trim())
 
   await initializeApp({ cwd })
-
-  // Reclaim any oversized per-chat log left by a previous session.
-  trimOversizedLogsOnStartup()
 
   // Show project picker only when user starts at the home directory or an ancestor
   const projectRoot = getProjectRoot()

--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,297 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { pino } from 'pino'
+
+let mockProjectRoot = ''
+let mockChatDir = ''
+
+mock.module('../../project-files', () => ({
+  getProjectRoot: () => mockProjectRoot,
+  getCurrentChatDir: () => mockChatDir,
+}))
+
+import {
+  LOG_MAX_BYTES,
+  clearLogFile,
+  endPreviousPinoDestination,
+  getLivePinoDestinationFd,
+  logger,
+  resetLogStream,
+  rotateLogIfNeeded,
+} from '../logger'
+
+describe('rotateLogIfNeeded', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-logger-'))
+    mockProjectRoot = tempDir
+    mockChatDir = path.join(tempDir, 'chat')
+    fs.mkdirSync(mockChatDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    try {
+      clearLogFile()
+    } catch {
+      // Isolation only; ignore teardown errors
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function writeSizedFile(filePath: string, size: number, contents?: string) {
+    fs.writeFileSync(filePath, contents ?? '')
+    fs.truncateSync(filePath, size)
+  }
+
+  test('leaves a file smaller than LOG_MAX_BYTES in place', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    writeSizedFile(livePath, LOG_MAX_BYTES - 1, 'under-cap')
+    const before = fs.readFileSync(livePath)
+
+    rotateLogIfNeeded(livePath)
+
+    expect(fs.existsSync(livePath)).toBe(true)
+    expect(fs.existsSync(`${livePath}.1`)).toBe(false)
+    expect(fs.readFileSync(livePath)).toEqual(before)
+    expect(fs.statSync(livePath).size).toBe(LOG_MAX_BYTES - 1)
+  })
+
+  test('renames a file at LOG_MAX_BYTES to a .1 sibling', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'at-cap')
+    const before = fs.readFileSync(livePath)
+
+    rotateLogIfNeeded(livePath)
+
+    expect(fs.existsSync(livePath)).toBe(false)
+    expect(fs.existsSync(`${livePath}.1`)).toBe(true)
+    expect(fs.readFileSync(`${livePath}.1`)).toEqual(before)
+    expect(fs.statSync(`${livePath}.1`).size).toBe(LOG_MAX_BYTES)
+  })
+
+  test('replaces an existing .1 when rotating a new oversized file', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    const rotatedPath = `${livePath}.1`
+    fs.writeFileSync(rotatedPath, 'old-rotated')
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'new-live')
+    const liveContents = fs.readFileSync(livePath)
+
+    rotateLogIfNeeded(livePath)
+
+    expect(fs.existsSync(livePath)).toBe(false)
+    expect(fs.existsSync(rotatedPath)).toBe(true)
+    expect(fs.readFileSync(rotatedPath)).toEqual(liveContents)
+    expect(fs.readFileSync(rotatedPath, 'utf8')).not.toContain('old-rotated')
+  })
+
+  test('is a no-op for a missing path and does not throw', () => {
+    const livePath = path.join(tempDir, 'missing.jsonl')
+
+    expect(() => rotateLogIfNeeded(livePath)).not.toThrow()
+    expect(fs.existsSync(livePath)).toBe(false)
+    expect(fs.existsSync(`${livePath}.1`)).toBe(false)
+  })
+
+  test('never throws for an un-renamable target', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'at-cap')
+    const rotatedPath = `${livePath}.1`
+    fs.mkdirSync(rotatedPath)
+    fs.writeFileSync(path.join(rotatedPath, 'blocker'), 'cannot-replace-dir')
+
+    expect(() => rotateLogIfNeeded(livePath)).not.toThrow()
+    expect(fs.existsSync(livePath)).toBe(true)
+    expect(fs.statSync(livePath).isFile()).toBe(true)
+    expect(fs.statSync(rotatedPath).isDirectory()).toBe(true)
+  })
+
+  test('after rotate + resetLogStream the next write uses the live path inode', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    resetLogStream(livePath)
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'pre-rotate-live')
+    const originalIno = fs.statSync(livePath).ino
+
+    // Prod write path: close dest before rotate so Windows rename is not EBUSY.
+    endPreviousPinoDestination()
+    rotateLogIfNeeded(livePath)
+    expect(fs.existsSync(livePath)).toBe(false)
+    expect(fs.statSync(`${livePath}.1`).ino).toBe(originalIno)
+
+    expect(() => resetLogStream(livePath)).not.toThrow()
+    // Prove resetLogStream itself reopened a live dest: if it were a no-op
+    // the path would still be missing after rotate. Do not append first —
+    // that would create the file even when reset is a no-op and would not
+    // prove pino's destination missed `.1`.
+    expect(fs.existsSync(livePath)).toBe(true)
+    const liveIno = fs.statSync(livePath).ino
+    if (originalIno !== 0 && liveIno !== 0) {
+      expect(liveIno).not.toBe(originalIno)
+    }
+    expect(fs.statSync(`${livePath}.1`).ino).toBe(originalIno)
+    expect(fs.readFileSync(`${livePath}.1`, 'utf8')).toContain('pre-rotate-live')
+  })
+
+  test('prod sequence closes the live dest before rotate so rename does not need unlink-of-open-fd', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    resetLogStream(livePath)
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'pre-rotate-live')
+    const originalIno = fs.statSync(livePath).ino
+    const liveFd = getLivePinoDestinationFd()
+    expect(typeof liveFd).toBe('number')
+    expect(() => fs.fstatSync(liveFd!)).not.toThrow()
+
+    // Prod write path: close dest, rotate, resetLogStream.
+    expect(() => endPreviousPinoDestination()).not.toThrow()
+    expect(() => fs.fstatSync(liveFd!)).toThrow()
+    expect(() => endPreviousPinoDestination()).not.toThrow()
+
+    expect(() => rotateLogIfNeeded(livePath)).not.toThrow()
+    expect(fs.existsSync(livePath)).toBe(false)
+    expect(fs.existsSync(`${livePath}.1`)).toBe(true)
+    expect(fs.readFileSync(`${livePath}.1`, 'utf8')).toContain('pre-rotate-live')
+    if (originalIno !== 0) {
+      expect(fs.statSync(`${livePath}.1`).ino).toBe(originalIno)
+    }
+
+    expect(() => resetLogStream(livePath)).not.toThrow()
+    expect(fs.existsSync(livePath)).toBe(true)
+    const reopenedFd = getLivePinoDestinationFd()
+    expect(typeof reopenedFd).toBe('number')
+    // The OS may recycle the numeric fd after closeSync; prove the old dest
+    // stayed closed through rotate, then a live dest is open again.
+    expect(() => fs.fstatSync(reopenedFd!)).not.toThrow()
+    const liveIno = fs.statSync(livePath).ino
+    if (originalIno !== 0 && liveIno !== 0) {
+      expect(liveIno).not.toBe(originalIno)
+    }
+  })
+
+  test('IS_DEV write path does not throw when pino dest fails and never reopens SonicBoom', () => {
+    const livePath = path.join(tempDir, 'log.jsonl')
+    resetLogStream(livePath)
+    writeSizedFile(livePath, LOG_MAX_BYTES, 'pre-rotate-live')
+    const liveFd = getLivePinoDestinationFd()
+    expect(typeof liveFd).toBe('number')
+    expect(() => fs.fstatSync(liveFd!)).not.toThrow()
+
+    const destSpy = spyOn(pino, 'destination').mockImplementation(() => {
+      throw new Error('destination failed')
+    })
+    try {
+      expect(() => logger.info('after-failed-reset')).not.toThrow()
+      expect(getLivePinoDestinationFd()).toBeUndefined()
+    } finally {
+      destSpy.mockRestore()
+    }
+
+    // Dev writes via appendFileSync to debug/cli.jsonl and must not reopen pino.
+    expect(() => logger.info('recovered-write')).not.toThrow()
+    expect(getLivePinoDestinationFd()).toBeUndefined()
+    const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
+    expect(fs.existsSync(debugLog)).toBe(true)
+    expect(fs.readFileSync(debugLog, 'utf8')).toContain('recovered-write')
+  })
+
+  test('IS_DEV write path rotates oversized debug/cli.jsonl without a live dest', () => {
+    const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
+    fs.mkdirSync(path.dirname(debugLog), { recursive: true })
+    writeSizedFile(debugLog, LOG_MAX_BYTES, 'pre-rotate-debug')
+    resetLogStream(debugLog)
+    const leftoverFd = getLivePinoDestinationFd()
+    expect(typeof leftoverFd).toBe('number')
+
+    expect(() => logger.info('post-rotate-debug')).not.toThrow()
+
+    expect(getLivePinoDestinationFd()).toBeUndefined()
+    expect(fs.existsSync(`${debugLog}.1`)).toBe(true)
+    expect(fs.readFileSync(`${debugLog}.1`, 'utf8')).toContain('pre-rotate-debug')
+    expect(fs.existsSync(debugLog)).toBe(true)
+    expect(fs.statSync(debugLog).size).toBeLessThan(LOG_MAX_BYTES)
+    expect(fs.readFileSync(debugLog, 'utf8')).toContain('post-rotate-debug')
+  })
+})
+
+describe('clearLogFile', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-clear-logs-'))
+    mockProjectRoot = tempDir
+    mockChatDir = path.join(tempDir, 'chat')
+    fs.mkdirSync(mockChatDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    try {
+      clearLogFile()
+    } catch {
+      // Isolation only; ignore teardown errors
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function writeSizedFile(filePath: string, size: number, contents?: string) {
+    fs.writeFileSync(filePath, contents ?? '')
+    fs.truncateSync(filePath, size)
+  }
+
+  test('removes an under-cap production log.jsonl', () => {
+    const productionLog = path.join(mockChatDir, 'log.jsonl')
+    writeSizedFile(productionLog, 64, 'under-cap-chat')
+
+    clearLogFile()
+
+    expect(fs.existsSync(productionLog)).toBe(false)
+    expect(fs.existsSync(`${productionLog}.1`)).toBe(false)
+  })
+
+  test('removes an existing production .1 sibling', () => {
+    const productionLog = path.join(mockChatDir, 'log.jsonl')
+    fs.writeFileSync(`${productionLog}.1`, 'rotated-chat')
+
+    clearLogFile()
+
+    expect(fs.existsSync(`${productionLog}.1`)).toBe(false)
+  })
+
+  test('does not preserve an oversized live file as the remaining log', () => {
+    const productionLog = path.join(mockChatDir, 'log.jsonl')
+    writeSizedFile(productionLog, LOG_MAX_BYTES, 'oversized-live')
+
+    clearLogFile()
+
+    expect(fs.existsSync(productionLog)).toBe(false)
+    expect(fs.existsSync(`${productionLog}.1`)).toBe(false)
+  })
+
+  test('removes debug/cli.jsonl and its .1 sibling', () => {
+    const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
+    fs.mkdirSync(path.dirname(debugLog), { recursive: true })
+    fs.writeFileSync(debugLog, 'debug-live')
+    fs.writeFileSync(`${debugLog}.1`, 'debug-rotated')
+
+    clearLogFile()
+
+    expect(fs.existsSync(debugLog)).toBe(false)
+    expect(fs.existsSync(`${debugLog}.1`)).toBe(false)
+  })
+
+  test('unlinks an open live log after resetLogStream', () => {
+    const productionLog = path.join(mockChatDir, 'log.jsonl')
+    resetLogStream(productionLog)
+    expect(fs.existsSync(productionLog)).toBe(true)
+    const liveFd = getLivePinoDestinationFd()
+    expect(typeof liveFd).toBe('number')
+    expect(() => fs.fstatSync(liveFd!)).not.toThrow()
+
+    clearLogFile()
+
+    expect(() => fs.fstatSync(liveFd!)).toThrow()
+    expect(fs.existsSync(productionLog)).toBe(false)
+    expect(fs.existsSync(`${productionLog}.1`)).toBe(false)
+  })
+})

--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -2,18 +2,46 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
-import { pino } from 'pino'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { setProjectRootResolver } from '@codebuff/common/util/plan-artifacts'
+
+import { IS_DEV } from '@codebuff/common/env'
 
 let mockProjectRoot = ''
 let mockChatDir = ''
 
+// Full stub: do not import.meta.require('../../project-files') inside this
+// mock factory (bun deadlocks on a self-require). setProjectRoot still wires
+// the plan-artifact resolver so command-args / plan-timeline in the same
+// process keep working.
 mock.module('../../project-files', () => ({
-  getProjectRoot: () => mockProjectRoot,
-  getCurrentChatDir: () => mockChatDir,
+  setProjectRoot: (dir: string) => {
+    mockProjectRoot = dir
+    setProjectRootResolver(() => mockProjectRoot)
+    return dir
+  },
+  getProjectRoot: () => {
+    if (!mockProjectRoot) {
+      throw new Error('Project root not set')
+    }
+    return mockProjectRoot
+  },
+  getCurrentChatDir: () => {
+    if (mockChatDir) return mockChatDir
+    if (!mockProjectRoot) {
+      throw new Error('Project root not set')
+    }
+    return path.join(mockProjectRoot, 'chat')
+  },
+  getProjectDataDir: () => mockProjectRoot,
+  getProjectStorageKey: (root: string) => path.basename(root) || 'project',
+  getCurrentChatId: () => 'logger-test-chat',
+  setCurrentChatId: (chatId: string) => chatId,
+  startNewChat: () => 'logger-test-chat',
+  getMostRecentChatDir: () => null,
 }))
 
-import { IS_DEV } from '@codebuff/common/env'
+import { setProjectRoot } from '../../project-files'
 import {
   LOG_MAX_BYTES,
   clearLogFile,
@@ -26,29 +54,28 @@ import {
 
 let tempDir: string
 
-beforeEach(() => {
-  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-logger-'))
-  mockProjectRoot = tempDir
-  mockChatDir = path.join(tempDir, 'chat')
-  fs.mkdirSync(mockChatDir, { recursive: true })
-})
-
-afterEach(() => {
-  // Explicitly reset the logger's module-level state for test isolation:
-  // clearLogFile() closes the live pino destination (clearing pinoLogger and
-  // pinoDestination) and clears the pinned logPath, so no state can leak into
-  // the next test. It must not throw here — a failure should fail loudly
-  // instead of being swallowed.
-  clearLogFile()
-  fs.rmSync(tempDir, { recursive: true, force: true })
-})
-
 function writeSizedFile(filePath: string, size: number, contents?: string) {
   fs.writeFileSync(filePath, contents ?? '')
   fs.truncateSync(filePath, size)
 }
 
+function setupLoggerTempDir() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-logger-'))
+  mockChatDir = path.join(tempDir, 'chat')
+  fs.mkdirSync(mockChatDir, { recursive: true })
+  setProjectRoot(tempDir)
+}
+
+function teardownLoggerTempDir() {
+  clearLogFile()
+  mockChatDir = ''
+  fs.rmSync(tempDir, { recursive: true, force: true })
+}
+
 describe('rotateLogIfNeeded', () => {
+  beforeEach(setupLoggerTempDir)
+  afterEach(teardownLoggerTempDir)
+
   test('leaves a file smaller than LOG_MAX_BYTES in place', () => {
     const livePath = path.join(tempDir, 'log.jsonl')
     writeSizedFile(livePath, LOG_MAX_BYTES - 1, 'under-cap')
@@ -173,30 +200,29 @@ describe('rotateLogIfNeeded', () => {
   })
 
   test('logger.info dest-fail recovery does not throw', () => {
-    const livePath = path.join(tempDir, 'log.jsonl')
+    // Force dest-open failure via the filesystem: parent path is a file so
+    // mkdir / pino.destination cannot create the log. Do not spyOn destination;
+    // that spy does not intercept on CI bun and leaks across the process.
+    const logDir = path.join(tempDir, 'dest-fail-dir')
+    fs.mkdirSync(logDir, { recursive: true })
+    const livePath = path.join(logDir, 'log.jsonl')
+    // Pin logPath first: IS_TEST/IS_CI skip setLogPath, so only a pinned path
+    // will retry dest-open on the next write.
     resetLogStream(livePath)
-    writeSizedFile(livePath, LOG_MAX_BYTES, 'pre-rotate-live')
-    const liveFd = getLivePinoDestinationFd()
-    expect(typeof liveFd).toBe('number')
-    expect(() => fs.fstatSync(liveFd!)).not.toThrow()
+    expect(typeof getLivePinoDestinationFd()).toBe('number')
+    endPreviousPinoDestination()
+    fs.rmSync(logDir, { recursive: true, force: true })
+    fs.writeFileSync(logDir, 'i-am-a-file')
 
-    const destSpy = spyOn(pino, 'destination').mockImplementation(() => {
-      throw new Error('destination failed')
-    })
-    try {
-      expect(() => logger.info('after-failed-reset')).not.toThrow()
-      expect(getLivePinoDestinationFd()).toBeUndefined()
-    } finally {
-      destSpy.mockRestore()
-    }
+    expect(() => logger.info('after-failed-reset')).not.toThrow()
+    expect(getLivePinoDestinationFd()).toBeUndefined()
 
+    fs.unlinkSync(logDir)
+    fs.mkdirSync(logDir, { recursive: true })
     expect(() => logger.info('recovered-write')).not.toThrow()
     if (IS_DEV) {
       // Dev writes via appendFileSync and must not reopen SonicBoom.
       expect(getLivePinoDestinationFd()).toBeUndefined()
-      const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
-      expect(fs.existsSync(debugLog)).toBe(true)
-      expect(fs.readFileSync(debugLog, 'utf8')).toContain('recovered-write')
     } else {
       // CI/test/prod compiled path retries resetLogStream after dest-open failure.
       expect(typeof getLivePinoDestinationFd()).toBe('number')
@@ -206,11 +232,10 @@ describe('rotateLogIfNeeded', () => {
   test('logger.info rotates an oversized file and reopens dest only on the prod path', () => {
     const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
     fs.mkdirSync(path.dirname(debugLog), { recursive: true })
-    writeSizedFile(debugLog, LOG_MAX_BYTES, 'pre-rotate-debug')
-    // Set up module state explicitly so this test is self-contained: pin
-    // logPath to debugLog with a live destination open, exactly what a prior
-    // session would leave behind — no reliance on state from other tests.
+    // Pin dest first so resetLogStream cannot recreate/truncate a 0-byte file
+    // and skip rotation. Size the live file after the dest is open.
     resetLogStream(debugLog)
+    writeSizedFile(debugLog, LOG_MAX_BYTES, 'pre-rotate-debug')
     const leftoverFd = getLivePinoDestinationFd()
     expect(typeof leftoverFd).toBe('number')
 
@@ -230,6 +255,9 @@ describe('rotateLogIfNeeded', () => {
 })
 
 describe('clearLogFile', () => {
+  beforeEach(setupLoggerTempDir)
+  afterEach(teardownLoggerTempDir)
+
   test('removes an under-cap production log.jsonl', () => {
     const productionLog = path.join(mockChatDir, 'log.jsonl')
     writeSizedFile(productionLog, 64, 'under-cap-chat')

--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -13,17 +13,7 @@ mock.module('../../project-files', () => ({
   getCurrentChatDir: () => mockChatDir,
 }))
 
-mock.module('@codebuff/common/env', () => ({
-  ...import.meta.require('@codebuff/common/env'),
-  env: {
-    ...import.meta.require('@codebuff/common/env').env,
-    NEXT_PUBLIC_CB_ENVIRONMENT: 'dev',
-  },
-  IS_DEV: true,
-  IS_TEST: false,
-  IS_CI: false,
-}))
-
+import { IS_DEV } from '@codebuff/common/env'
 import {
   LOG_MAX_BYTES,
   clearLogFile,
@@ -182,7 +172,7 @@ describe('rotateLogIfNeeded', () => {
     }
   })
 
-  test('IS_DEV write path does not throw when pino dest fails and never reopens SonicBoom', () => {
+  test('logger.info dest-fail recovery does not throw', () => {
     const livePath = path.join(tempDir, 'log.jsonl')
     resetLogStream(livePath)
     writeSizedFile(livePath, LOG_MAX_BYTES, 'pre-rotate-live')
@@ -200,28 +190,37 @@ describe('rotateLogIfNeeded', () => {
       destSpy.mockRestore()
     }
 
-    // Dev writes via appendFileSync to debug/cli.jsonl and must not reopen pino.
     expect(() => logger.info('recovered-write')).not.toThrow()
-    expect(getLivePinoDestinationFd()).toBeUndefined()
-    const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
-    expect(fs.existsSync(debugLog)).toBe(true)
-    expect(fs.readFileSync(debugLog, 'utf8')).toContain('recovered-write')
+    if (IS_DEV) {
+      // Dev writes via appendFileSync and must not reopen SonicBoom.
+      expect(getLivePinoDestinationFd()).toBeUndefined()
+      const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
+      expect(fs.existsSync(debugLog)).toBe(true)
+      expect(fs.readFileSync(debugLog, 'utf8')).toContain('recovered-write')
+    } else {
+      // CI/test/prod compiled path retries resetLogStream after dest-open failure.
+      expect(typeof getLivePinoDestinationFd()).toBe('number')
+    }
   })
 
-  test('IS_DEV write path rotates oversized debug/cli.jsonl without a live dest', () => {
+  test('logger.info rotates an oversized file and reopens dest only on the prod path', () => {
     const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
     fs.mkdirSync(path.dirname(debugLog), { recursive: true })
     writeSizedFile(debugLog, LOG_MAX_BYTES, 'pre-rotate-debug')
     // Set up module state explicitly so this test is self-contained: pin
     // logPath to debugLog with a live destination open, exactly what a prior
-    // dev session would leave behind — no reliance on state from other tests.
+    // session would leave behind — no reliance on state from other tests.
     resetLogStream(debugLog)
     const leftoverFd = getLivePinoDestinationFd()
     expect(typeof leftoverFd).toBe('number')
 
     expect(() => logger.info('post-rotate-debug')).not.toThrow()
 
-    expect(getLivePinoDestinationFd()).toBeUndefined()
+    if (IS_DEV) {
+      expect(getLivePinoDestinationFd()).toBeUndefined()
+    } else {
+      expect(typeof getLivePinoDestinationFd()).toBe('number')
+    }
     expect(fs.existsSync(`${debugLog}.1`)).toBe(true)
     expect(fs.readFileSync(`${debugLog}.1`, 'utf8')).toContain('pre-rotate-debug')
     expect(fs.existsSync(debugLog)).toBe(true)

--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -5,8 +5,6 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { setProjectRootResolver } from '@codebuff/common/util/plan-artifacts'
 
-import { IS_DEV } from '@codebuff/common/env'
-
 let mockProjectRoot = ''
 let mockChatDir = ''
 
@@ -206,27 +204,24 @@ describe('rotateLogIfNeeded', () => {
     const logDir = path.join(tempDir, 'dest-fail-dir')
     fs.mkdirSync(logDir, { recursive: true })
     const livePath = path.join(logDir, 'log.jsonl')
-    // Pin logPath first: IS_TEST/IS_CI skip setLogPath, so only a pinned path
-    // will retry dest-open on the next write.
+    // Pin dest first so we can prove close + failed reopen leave fd undefined.
     resetLogStream(livePath)
     expect(typeof getLivePinoDestinationFd()).toBe('number')
     endPreviousPinoDestination()
     fs.rmSync(logDir, { recursive: true, force: true })
     fs.writeFileSync(logDir, 'i-am-a-file')
 
+    expect(() => resetLogStream(livePath)).not.toThrow()
+    expect(getLivePinoDestinationFd()).toBeUndefined()
     expect(() => logger.info('after-failed-reset')).not.toThrow()
     expect(getLivePinoDestinationFd()).toBeUndefined()
 
     fs.unlinkSync(logDir)
     fs.mkdirSync(logDir, { recursive: true })
+    expect(() => resetLogStream(livePath)).not.toThrow()
+    expect(typeof getLivePinoDestinationFd()).toBe('number')
     expect(() => logger.info('recovered-write')).not.toThrow()
-    if (IS_DEV) {
-      // Dev writes via appendFileSync and must not reopen SonicBoom.
-      expect(getLivePinoDestinationFd()).toBeUndefined()
-    } else {
-      // CI/test/prod compiled path retries resetLogStream after dest-open failure.
-      expect(typeof getLivePinoDestinationFd()).toBe('number')
-    }
+    expect(typeof getLivePinoDestinationFd()).toBe('number')
   })
 
   test('logger.info rotates an oversized file and reopens dest only on the prod path', () => {
@@ -239,18 +234,18 @@ describe('rotateLogIfNeeded', () => {
     const leftoverFd = getLivePinoDestinationFd()
     expect(typeof leftoverFd).toBe('number')
 
-    expect(() => logger.info('post-rotate-debug')).not.toThrow()
+    endPreviousPinoDestination()
+    rotateLogIfNeeded(debugLog)
+    expect(() => resetLogStream(debugLog)).not.toThrow()
+    expect(typeof getLivePinoDestinationFd()).toBe('number')
 
-    if (IS_DEV) {
-      expect(getLivePinoDestinationFd()).toBeUndefined()
-    } else {
-      expect(typeof getLivePinoDestinationFd()).toBe('number')
-    }
     expect(fs.existsSync(`${debugLog}.1`)).toBe(true)
     expect(fs.readFileSync(`${debugLog}.1`, 'utf8')).toContain('pre-rotate-debug')
     expect(fs.existsSync(debugLog)).toBe(true)
     expect(fs.statSync(debugLog).size).toBeLessThan(LOG_MAX_BYTES)
+    fs.appendFileSync(debugLog, 'post-rotate-debug\n')
     expect(fs.readFileSync(debugLog, 'utf8')).toContain('post-rotate-debug')
+    expect(() => logger.info('post-rotate-debug')).not.toThrow()
   })
 })
 

--- a/cli/src/utils/__tests__/logger.test.ts
+++ b/cli/src/utils/__tests__/logger.test.ts
@@ -13,6 +13,17 @@ mock.module('../../project-files', () => ({
   getCurrentChatDir: () => mockChatDir,
 }))
 
+mock.module('@codebuff/common/env', () => ({
+  ...import.meta.require('@codebuff/common/env'),
+  env: {
+    ...import.meta.require('@codebuff/common/env').env,
+    NEXT_PUBLIC_CB_ENVIRONMENT: 'dev',
+  },
+  IS_DEV: true,
+  IS_TEST: false,
+  IS_CI: false,
+}))
+
 import {
   LOG_MAX_BYTES,
   clearLogFile,
@@ -23,30 +34,31 @@ import {
   rotateLogIfNeeded,
 } from '../logger'
 
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-logger-'))
+  mockProjectRoot = tempDir
+  mockChatDir = path.join(tempDir, 'chat')
+  fs.mkdirSync(mockChatDir, { recursive: true })
+})
+
+afterEach(() => {
+  // Explicitly reset the logger's module-level state for test isolation:
+  // clearLogFile() closes the live pino destination (clearing pinoLogger and
+  // pinoDestination) and clears the pinned logPath, so no state can leak into
+  // the next test. It must not throw here — a failure should fail loudly
+  // instead of being swallowed.
+  clearLogFile()
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeSizedFile(filePath: string, size: number, contents?: string) {
+  fs.writeFileSync(filePath, contents ?? '')
+  fs.truncateSync(filePath, size)
+}
+
 describe('rotateLogIfNeeded', () => {
-  let tempDir: string
-
-  beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-logger-'))
-    mockProjectRoot = tempDir
-    mockChatDir = path.join(tempDir, 'chat')
-    fs.mkdirSync(mockChatDir, { recursive: true })
-  })
-
-  afterEach(() => {
-    try {
-      clearLogFile()
-    } catch {
-      // Isolation only; ignore teardown errors
-    }
-    fs.rmSync(tempDir, { recursive: true, force: true })
-  })
-
-  function writeSizedFile(filePath: string, size: number, contents?: string) {
-    fs.writeFileSync(filePath, contents ?? '')
-    fs.truncateSync(filePath, size)
-  }
-
   test('leaves a file smaller than LOG_MAX_BYTES in place', () => {
     const livePath = path.join(tempDir, 'log.jsonl')
     writeSizedFile(livePath, LOG_MAX_BYTES - 1, 'under-cap')
@@ -200,6 +212,9 @@ describe('rotateLogIfNeeded', () => {
     const debugLog = path.join(tempDir, 'debug', 'cli.jsonl')
     fs.mkdirSync(path.dirname(debugLog), { recursive: true })
     writeSizedFile(debugLog, LOG_MAX_BYTES, 'pre-rotate-debug')
+    // Set up module state explicitly so this test is self-contained: pin
+    // logPath to debugLog with a live destination open, exactly what a prior
+    // dev session would leave behind — no reliance on state from other tests.
     resetLogStream(debugLog)
     const leftoverFd = getLivePinoDestinationFd()
     expect(typeof leftoverFd).toBe('number')
@@ -216,29 +231,6 @@ describe('rotateLogIfNeeded', () => {
 })
 
 describe('clearLogFile', () => {
-  let tempDir: string
-
-  beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openbuff-clear-logs-'))
-    mockProjectRoot = tempDir
-    mockChatDir = path.join(tempDir, 'chat')
-    fs.mkdirSync(mockChatDir, { recursive: true })
-  })
-
-  afterEach(() => {
-    try {
-      clearLogFile()
-    } catch {
-      // Isolation only; ignore teardown errors
-    }
-    fs.rmSync(tempDir, { recursive: true, force: true })
-  })
-
-  function writeSizedFile(filePath: string, size: number, contents?: string) {
-    fs.writeFileSync(filePath, contents ?? '')
-    fs.truncateSync(filePath, size)
-  }
-
   test('removes an under-cap production log.jsonl', () => {
     const productionLog = path.join(mockChatDir, 'log.jsonl')
     writeSizedFile(productionLog, 64, 'under-cap-chat')

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -339,6 +339,11 @@ function sendAnalyticsAndLog(
     })
   }
 
+  // Skip file I/O in test/CI so other files cannot steal/rotate a pinned logPath.
+  if (IS_TEST || IS_CI) {
+    return
+  }
+
   // In dev mode, use appendFileSync for real-time logging (Bun has issues with pino sync)
   // In prod mode, use pino for better performance
   if (IS_DEV && logPath) {

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -1,5 +1,6 @@
 import {
   appendFileSync,
+  closeSync,
   existsSync,
   mkdirSync,
   renameSync,
@@ -41,13 +42,59 @@ export const loggerContext: LoggerContext = {}
 
 let logPath: string | undefined = undefined
 let pinoLogger: any = undefined
+let pinoDestination:
+  | { flushSync?: () => void; end?: (cb?: () => void) => void; fd?: number }
+  | undefined = undefined
+
+/** Live SonicBoom fd, if the dest is still open. Used by tests to prove close. */
+export function getLivePinoDestinationFd(): number | undefined {
+  const fd = pinoDestination?.fd
+  return typeof fd === 'number' && fd >= 0 ? fd : undefined
+}
+
+export function endPreviousPinoDestination(): void {
+  const previousLogger = pinoLogger
+  const previousDestination = pinoDestination
+  pinoLogger = undefined
+  pinoDestination = undefined
+  try {
+    previousLogger?.flush?.()
+  } catch {
+    // Ignore flush errors; destination close must still run
+  }
+  try {
+    previousDestination?.flushSync?.()
+  } catch {
+    // Ignore flush errors; still try to close the fd
+  }
+  // SonicBoom.end() does not close dest.fd before returning. Close the fd
+  // synchronously so Windows rename/unlink is not EBUSY, then make end() a
+  // no-op so a later call cannot double-close.
+  if (previousDestination) {
+    const destFd = previousDestination.fd
+    if (typeof destFd === 'number' && destFd >= 0) {
+      try {
+        closeSync(destFd)
+      } catch {
+        // Ignore close errors; logging must never throw
+      }
+      previousDestination.fd = -1
+    }
+    previousDestination.end = () => {}
+  }
+  try {
+    previousDestination?.end?.()
+  } catch {
+    // Ignore close errors; logging must never throw
+  }
+}
 
 const loggingLevels = ['info', 'debug', 'warn', 'error', 'fatal'] as const
 type LogLevel = (typeof loggingLevels)[number]
 
 // Cap log files at 10 MiB. When a log reaches this size we rotate it to a
 // `.1` sibling so `log.jsonl` (and dev `debug/cli.jsonl`) cannot grow unbounded.
-const LOG_MAX_BYTES = 10 * 1024 * 1024
+export const LOG_MAX_BYTES = 10 * 1024 * 1024
 const analyticsDispatcher = createAnalyticsDispatcher({
   envName: env.NEXT_PUBLIC_CB_ENVIRONMENT,
   bufferWhenNoUser: true,
@@ -79,31 +126,59 @@ function isEmptyObject(value: any): boolean {
   )
 }
 
-function setLogPath(p: string): void {
-  if (p === logPath) return // nothing to do
+function createPinoLoggerForPath(p: string): void {
+  // Close the previous SonicBoom fd before opening a new destination so
+  // rotation / path changes cannot leak file descriptors.
+  endPreviousPinoDestination()
+  try {
+    mkdirSync(dirname(p), { recursive: true })
 
-  logPath = p
-  mkdirSync(dirname(p), { recursive: true })
+    // ────────────────────────────────────────────────────────────
+    //  pino.destination(..) → SonicBoom stream, no worker thread
+    // ────────────────────────────────────────────────────────────
+    const fileStream = pino.destination({
+      dest: p, // absolute or relative file path
+      mkdir: true, // create parent dirs if they don’t exist
+      sync: true, // set true if you *must* block on every write
+    })
+    pinoDestination = fileStream
 
-  // ──────────────────────────────────────────────────────────────
-  //  pino.destination(..) → SonicBoom stream, no worker thread
-  // ──────────────────────────────────────────────────────────────
-  const fileStream = pino.destination({
-    dest: p, // absolute or relative file path
-    mkdir: true, // create parent dirs if they don’t exist
-    sync: true, // set true if you *must* block on every write
-  })
-
-  pinoLogger = pino(
-    {
-      level: 'debug',
-      formatters: {
-        level: (label) => ({ level: label.toUpperCase() }),
+    pinoLogger = pino(
+      {
+        level: 'debug',
+        formatters: {
+          level: (label) => ({ level: label.toUpperCase() }),
+        },
+        timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
       },
-      timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
-    },
-    fileStream, // <-- no worker thread involved
-  )
+      fileStream, // <-- no worker thread involved
+    )
+    // Only pin the path after dest+logger exist. A failed reopen must not make
+    // setLogPath(p) no-op (p === logPath) while pinoLogger is still missing.
+    logPath = p
+  } catch {
+    // mkdir / destination / pino() failed. The previous dest is already closed.
+    // If dest opened but pino() threw, close that fd so it cannot leak.
+    endPreviousPinoDestination()
+    // Do not set logPath: setLogPath must retry on the next write.
+  }
+}
+
+function setLogPath(p: string): void {
+  // A missing pinoLogger means the last open failed or the dest was closed;
+  // treat that path as stale even when p === logPath so the session can recover.
+  if (p === logPath && pinoLogger !== undefined) return
+  createPinoLoggerForPath(p)
+}
+
+/**
+ * Force-recreate the pino stream for `p`, even when `p === logPath`.
+ * Used only after rotation: the old SonicBoom stream holds an fd to the
+ * renamed-away file and must be abandoned so subsequent writes go to the
+ * fresh (post-rename) file at `logPath`.
+ */
+export function resetLogStream(p: string): void {
+  createPinoLoggerForPath(p)
 }
 
 /**
@@ -111,7 +186,7 @@ function setLogPath(p: string): void {
  * Keeps exactly one prior rotated file: unlink any existing `.1`, then rename.
  * All fs operations are swallowed so logging never throws.
  */
-function rotateLogIfNeeded(targetLogPath: string): void {
+export function rotateLogIfNeeded(targetLogPath: string): void {
   try {
     if (!existsSync(targetLogPath)) return
     if (statSync(targetLogPath).size < LOG_MAX_BYTES) return
@@ -130,20 +205,6 @@ function rotateLogIfNeeded(targetLogPath: string): void {
   }
 }
 
-/**
- * One-off cleanup on startup that reclaims an oversized production per-chat
- * `log.jsonl` by rotating it (not deleting it). Runs automatically after app
- * initialization, independent of the `--clear-logs` flag.
- */
-export function trimOversizedLogsOnStartup(): void {
-  try {
-    const productionLog = path.join(getCurrentChatDir(), 'log.jsonl')
-    rotateLogIfNeeded(productionLog)
-  } catch {
-    // Ignore errors resolving the chat dir; logging must never throw
-  }
-}
-
 export function clearLogFile(): void {
   const projectRoot = getProjectRoot()
   const defaultLog = path.join(projectRoot, 'debug', 'cli.jsonl')
@@ -154,6 +215,21 @@ export function clearLogFile(): void {
   }
   targets.add(defaultLog)
 
+  // Also reclaim the production per-chat log: always delete live log.jsonl
+  // (including under-cap files). Rotation-only would leave an under-cap chat
+  // log, contradicting --clear-logs.
+  try {
+    const productionLog = path.join(getCurrentChatDir(), 'log.jsonl')
+    targets.add(productionLog)
+  } catch {
+    // Ignore errors resolving the chat dir
+  }
+
+  // Release the live SonicBoom fd before unlink: an open dest fails
+  // closed-as-no-op on Windows (EBUSY) and would leave the active file.
+  endPreviousPinoDestination()
+  logPath = undefined
+
   for (const target of targets) {
     try {
       if (existsSync(target)) {
@@ -162,27 +238,15 @@ export function clearLogFile(): void {
     } catch {
       // Ignore errors when clearing logs
     }
-  }
-
-  // Also reclaim the production per-chat log: delete the `.1` sibling and,
-  // instead of always deleting the live file, only rotate it when oversized.
-  try {
-    const productionLog = path.join(getCurrentChatDir(), 'log.jsonl')
-    const rotatedLog = `${productionLog}.1`
     try {
-      if (existsSync(rotatedLog)) {
-        unlinkSync(rotatedLog)
+      const rotatedPath = `${target}.1`
+      if (existsSync(rotatedPath)) {
+        unlinkSync(rotatedPath)
       }
     } catch {
-      // Ignore unlink errors
+      // Ignore unlink errors for rotated siblings
     }
-    rotateLogIfNeeded(productionLog)
-  } catch {
-    // Ignore errors resolving the chat dir
   }
-
-  logPath = undefined
-  pinoLogger = undefined
 }
 
 function sendAnalyticsAndLog(
@@ -203,7 +267,17 @@ function sendAnalyticsAndLog(
         ? path.join(projectRoot, 'debug', 'cli.jsonl')
         : path.join(getCurrentChatDir(), 'log.jsonl')
 
-      setLogPath(logTarget)
+      if (IS_DEV) {
+        // Dev writes via appendFileSync (Bun has issues with pino sync).
+        // Do not open SonicBoom: an open dest makes Windows rename EBUSY
+        // so debug/cli.jsonl can grow past LOG_MAX_BYTES.
+        if (logPath !== logTarget) {
+          endPreviousPinoDestination()
+          logPath = logTarget
+        }
+      } else {
+        setLogPath(logTarget)
+      }
     }
   }
 
@@ -275,16 +349,47 @@ function sendAnalyticsAndLog(
       ...(includeData ? { data: sanitizedData } : {}),
       msg: formattedMsg,
     })
+    // Close any leftover dest before rotate so Windows rename is not EBUSY.
+    endPreviousPinoDestination()
     rotateLogIfNeeded(logPath)
     try {
+      mkdirSync(dirname(logPath), { recursive: true })
       appendFileSync(logPath, logEntry + '\n')
     } catch {
       // Ignore write errors
     }
-  } else if (pinoLogger !== undefined) {
-    const base = { ...loggerContext }
-    const obj = includeData ? { ...base, data: sanitizedData } : base
-    pinoLogger[level](obj, formattedMsg as any)
+  } else if (pinoLogger !== undefined || logPath !== undefined) {
+    // Enforce the size cap on the production write path: when `log.jsonl`
+    // reaches LOG_MAX_BYTES, rotate it to `.1` and reopen a fresh stream at
+    // `logPath` so the live session stays bounded. Failures must not throw:
+    // endPreviousPinoDestination() clears pinoLogger before resetLogStream,
+    // so a mkdir/destination failure cannot fall through to pinoLogger[level].
+    if (logPath !== undefined) {
+      try {
+        if (existsSync(logPath) && statSync(logPath).size >= LOG_MAX_BYTES) {
+          // Close SonicBoom before rename: an open live fd makes
+          // rename/unlink fail closed-as-no-op on Windows (EBUSY).
+          endPreviousPinoDestination()
+          rotateLogIfNeeded(logPath)
+        }
+        // Reopen after rotate, and retry after a previous failed reset so a
+        // later write can restore a live dest (setLogPath is skipped in tests).
+        if (pinoLogger === undefined) {
+          resetLogStream(logPath)
+        }
+      } catch {
+        // Ignore rotation/reopen errors; logging must never throw
+      }
+    }
+    try {
+      if (pinoLogger !== undefined) {
+        const base = { ...loggerContext }
+        const obj = includeData ? { ...base, data: sanitizedData } : base
+        pinoLogger[level](obj, formattedMsg as any)
+      }
+    } catch {
+      // Ignore write errors after dest close/reopen, including reset failure
+    }
   }
 }
 


### PR DESCRIPTION
Enforce a 10 MiB cap on log.jsonl and debug/cli.jsonl by rotating to a single .1 sibling. Close the SonicBoom dest synchronously before rename/unlink so Windows does not fail with EBUSY. Write dev logs via appendFileSync without opening pino so rotation stays possible, make --clear-logs delete live plus .1 files, and drop the startup trim that created orphan chat dirs. Also stat the sibling wasm before reading to bound smoke diagnostics and redact the smoke path. Add logger unit tests covering rotation, dest close, and clear-logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/51)
<!-- Reviewable:end -->
