### PR TITLE
test(cli): drop process-wide logger mocks in direnv, chat-history, and image tests

### DIFF
--- a/cli/src/init/__tests__/init-direnv.test.ts
+++ b/cli/src/init/__tests__/init-direnv.test.ts
@@ -4,7 +4,6 @@ import {
   expect,
   beforeEach,
   afterEach,
-  mock,
   spyOn,
 } from 'bun:test'
 import type { SpawnSyncReturns } from 'child_process'
@@ -12,21 +11,14 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 
+import { logger } from '../../utils/logger'
 import {
   findEnvrcDirectory,
   isDirenvAvailable,
   getDirenvExport,
   initializeDirenv,
+  resetDirenvStateForTests,
 } from '../init-direnv'
-
-mock.module('../utils/logger', () => ({
-  logger: {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-  },
-}))
 
 describe('init-direnv', () => {
   describe('findEnvrcDirectory', () => {
@@ -135,20 +127,21 @@ describe('init-direnv', () => {
       expect(result).toBeNull()
     })
 
-    test('handles unreadable directory gracefully', () => {
-      const restrictedDir = path.join(tempDir, 'restricted')
-      fs.mkdirSync(restrictedDir)
+    test.skipIf(os.platform() === 'win32' || process.getuid?.() === 0)(
+      'handles unreadable directory gracefully',
+      () => {
+        const restrictedDir = path.join(tempDir, 'restricted')
+        fs.mkdirSync(restrictedDir)
 
-      if (os.platform() === 'win32' || process.getuid?.() === 0) return
-
-      fs.chmodSync(restrictedDir, 0o000)
-      try {
-        const result = findEnvrcDirectory(restrictedDir)
-        expect(result).toBeNull()
-      } finally {
-        fs.chmodSync(restrictedDir, 0o755)
-      }
-    })
+        fs.chmodSync(restrictedDir, 0o000)
+        try {
+          const result = findEnvrcDirectory(restrictedDir)
+          expect(result).toBeNull()
+        } finally {
+          fs.chmodSync(restrictedDir, 0o755)
+        }
+      },
+    )
 
     test('resolves relative paths', () => {
       fs.writeFileSync(path.join(tempDir, '.envrc'), 'export FOO=bar')
@@ -177,20 +170,84 @@ describe('init-direnv', () => {
   })
 
   describe('isDirenvAvailable', () => {
+    let spawnSyncSpy: ReturnType<typeof spyOn>
+    let platformSpy: ReturnType<typeof spyOn>
+    let childProcess: typeof import('child_process')
+
+    beforeEach(async () => {
+      childProcess = await import('child_process')
+      spawnSyncSpy = spyOn(childProcess, 'spawnSync')
+      platformSpy = spyOn(os, 'platform')
+    })
+
+    afterEach(() => {
+      spawnSyncSpy.mockRestore()
+      platformSpy.mockRestore()
+    })
+
     test('returns boolean', () => {
+      platformSpy.mockReturnValue('linux')
+      spawnSyncSpy.mockReturnValue({
+        status: 0,
+        stdout: '/usr/local/bin/direnv',
+        stderr: '',
+        pid: 1234,
+        output: [],
+        signal: null,
+      } as SpawnSyncReturns<string>)
+
       const result = isDirenvAvailable()
       expect(typeof result).toBe('boolean')
     })
 
     test('returns false on Windows', () => {
+      platformSpy.mockReturnValue('win32')
+
       const result = isDirenvAvailable()
-      expect(typeof result).toBe('boolean')
-      if (os.platform() === 'win32') {
-        expect(result).toBe(false)
-      }
+
+      expect(result).toBe(false)
+      expect(spawnSyncSpy).not.toHaveBeenCalled()
+    })
+
+    test('returns true when direnv is on PATH', () => {
+      platformSpy.mockReturnValue('linux')
+      spawnSyncSpy.mockReturnValue({
+        status: 0,
+        stdout: '/usr/local/bin/direnv\n',
+        stderr: '',
+        pid: 1234,
+        output: [],
+        signal: null,
+      } as SpawnSyncReturns<string>)
+
+      expect(isDirenvAvailable()).toBe(true)
+    })
+
+    test('returns false when direnv is missing', () => {
+      platformSpy.mockReturnValue('linux')
+      spawnSyncSpy.mockReturnValue({
+        status: 1,
+        stdout: '',
+        stderr: '',
+        pid: 1234,
+        output: [],
+        signal: null,
+      } as SpawnSyncReturns<string>)
+
+      expect(isDirenvAvailable()).toBe(false)
     })
 
     test('returns consistent results on repeated calls', () => {
+      platformSpy.mockReturnValue('linux')
+      spawnSyncSpy.mockReturnValue({
+        status: 0,
+        stdout: '/usr/local/bin/direnv',
+        stderr: '',
+        pid: 1234,
+        output: [],
+        signal: null,
+      } as SpawnSyncReturns<string>)
+
       const result1 = isDirenvAvailable()
       const result2 = isDirenvAvailable()
       const result3 = isDirenvAvailable()
@@ -272,6 +329,7 @@ describe('init-direnv', () => {
     })
 
     test('returns null and warns when .envrc is blocked', () => {
+      const warnSpy = spyOn(logger, 'warn')
       spawnSyncSpy.mockReturnValue({
         status: 1,
         stdout: '',
@@ -282,9 +340,16 @@ describe('init-direnv', () => {
         signal: null,
       } as SpawnSyncReturns<string>)
 
-      const result = getDirenvExport(tempDir)
+      try {
+        const result = getDirenvExport(tempDir)
 
-      expect(result).toBeNull()
+        expect(result).toBeNull()
+        expect(warnSpy).toHaveBeenCalledWith(
+          'direnv: .envrc is blocked. Run `direnv allow` to enable.',
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
     })
 
     test('returns null when stdout is empty (no env changes)', () => {
@@ -305,7 +370,7 @@ describe('init-direnv', () => {
     test('returns null when stdout is only whitespace', () => {
       spawnSyncSpy.mockReturnValue({
         status: 0,
-        stdout: '   \n\t  ',
+        stdout: ['   ', '\n', '\t', '  '].join(''),
         stderr: '',
         pid: 1234,
         output: [],
@@ -369,16 +434,21 @@ describe('init-direnv', () => {
     let childProcess: typeof import('child_process')
     let originalEnv: NodeJS.ProcessEnv
     let originalCwd: string
+    let platformSpy: ReturnType<typeof spyOn>
 
     beforeEach(async () => {
+      resetDirenvStateForTests()
       tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'direnv-init-test-'))
       originalEnv = { ...process.env }
       originalCwd = process.cwd()
       childProcess = await import('child_process')
       spawnSyncSpy = spyOn(childProcess, 'spawnSync')
+      // initializeDirenv returns before spawn mocks if the host is Windows
+      platformSpy = spyOn(os, 'platform').mockReturnValue('linux')
     })
 
     afterEach(() => {
+      resetDirenvStateForTests()
       for (const key of Object.keys(process.env)) {
         if (!(key in originalEnv)) {
           delete process.env[key]
@@ -390,6 +460,7 @@ describe('init-direnv', () => {
       process.chdir(originalCwd)
       fs.rmSync(tempDir, { recursive: true, force: true })
       spawnSyncSpy.mockRestore()
+      platformSpy.mockRestore()
     })
 
     test('sets environment variables from direnv export', () => {

--- a/cli/src/init/init-direnv.ts
+++ b/cli/src/init/init-direnv.ts
@@ -12,6 +12,12 @@ import { logger } from '../utils/logger'
 const originalEnvValues = new Map<string, string | undefined>()
 let appliedDirenvKeys = new Set<string>()
 
+/** @internal Test-only: clear process-global direnv snapshots between tests. */
+export function resetDirenvStateForTests(): void {
+  originalEnvValues.clear()
+  appliedDirenvKeys = new Set()
+}
+
 function restorePreviousDirenvEnvironment(): void {
   for (const key of appliedDirenvKeys) {
     const originalValue = originalEnvValues.get(key)

--- a/cli/src/utils/__tests__/chat-history.test.ts
+++ b/cli/src/utils/__tests__/chat-history.test.ts
@@ -9,16 +9,6 @@ mock.module('../../project-files', () => ({
   getProjectDataDir: () => tempDataDir,
 }))
 
-mock.module('../logger', () => ({
-  logger: {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    fatal: () => {},
-  },
-}))
-
 import { deleteChatSession, getAllChats } from '../chat-history'
 
 function writeChat(chatId: string, prompt: string) {

--- a/cli/src/utils/__tests__/image-dimensions.test.ts
+++ b/cli/src/utils/__tests__/image-dimensions.test.ts
@@ -1,30 +1,32 @@
+import { randomFillSync } from 'crypto'
 import { mkdirSync, rmSync } from 'fs'
+import os from 'os'
 import path from 'path'
 
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { Jimp } from 'jimp'
 
-import { setProjectRoot } from '../../project-files'
+import { getProjectRoot, setProjectRoot } from '../../project-files'
 import { calculateDisplaySize } from '../image-display'
 import { processImageFile } from '../image-handler'
 
-// Mock the logger to prevent analytics initialization errors in tests
-mock.module('../logger', () => ({
-  logger: {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    fatal: () => {},
-  },
-}))
-
-const TEST_DIR = path.join(__dirname, 'temp-test-images')
+let TEST_DIR: string
+let previousProjectRoot: string | undefined
 
 beforeEach(async () => {
+  TEST_DIR = path.join(
+    os.tmpdir(),
+    `temp-test-images-${process.pid}-${Date.now()}`,
+  )
   mkdirSync(TEST_DIR, { recursive: true })
   // Create debug directory for logger
   mkdirSync(path.join(TEST_DIR, 'debug'), { recursive: true })
+
+  try {
+    previousProjectRoot = getProjectRoot()
+  } catch {
+    previousProjectRoot = undefined
+  }
 
   // Set project root so logger doesn't throw
   setProjectRoot(TEST_DIR)
@@ -50,6 +52,10 @@ beforeEach(async () => {
 })
 
 afterEach(() => {
+  // Always restore a live root before deleting TEST_DIR. If getProjectRoot()
+  // threw in beforeEach, previousProjectRoot is unset and leaving TEST_DIR
+  // installed would point the global root at a removed path.
+  setProjectRoot(previousProjectRoot ?? process.cwd())
   try {
     rmSync(TEST_DIR, { recursive: true, force: true })
   } catch {
@@ -88,25 +94,11 @@ describe('Image Dimensions', () => {
     })
 
     test('should return compressed dimensions when image is compressed', async () => {
-      // Create a large image that will be compressed
-      const largeImage = new Jimp({
-        width: 2000,
-        height: 1000,
-        color: 0xff00ffff,
-      })
-
-      // Fill with varied data to make it less compressible (using unsigned values)
-      for (let y = 0; y < 1000; y++) {
-        for (let x = 0; x < 2000; x++) {
-          const r = (x * y) % 256
-          const g = (x + y) % 256
-          const b = x % 256
-          const a = 255
-          // Jimp uses RGBA format as unsigned 32-bit: 0xRRGGBBAA
-          const color = ((r << 24) | (g << 16) | (b << 8) | a) >>> 0
-          largeImage.setPixelColor(color, x, y)
-        }
-      }
+      // Compression triggers on base64 size, not dimensions. A solid fill PNG
+      // stays under MAX_IMAGE_BASE64_SIZE. Fill the bitmap once (no 2e6
+      // setPixelColor loop) so the PNG exceeds the 1MB gate.
+      const largeImage = new Jimp({ width: 2000, height: 1000 })
+      randomFillSync(largeImage.bitmap.data)
       await largeImage.write(
         path.join(TEST_DIR, 'large-2000x1000.png') as `${string}.${string}`,
       )
@@ -114,15 +106,11 @@ describe('Image Dimensions', () => {
       const result = await processImageFile('large-2000x1000.png', TEST_DIR)
 
       expect(result.success).toBe(true)
+      expect(result.wasCompressed).toBe(true)
       expect(result.imagePart).toBeDefined()
-      // Dimensions should be defined even after compression
-      expect(result.imagePart!.width).toBeDefined()
-      expect(result.imagePart!.height).toBeDefined()
-      // After compression, dimensions should be reduced
-      if (result.wasCompressed) {
-        expect(result.imagePart!.width).toBeLessThanOrEqual(1500) // Max dimension limit
-        expect(result.imagePart!.height).toBeLessThanOrEqual(1500)
-      }
+      // First dimension limit is 1500; wide images scale width and keep 2:1
+      expect(result.imagePart!.width).toBe(1500)
+      expect(result.imagePart!.height).toBe(750)
     })
   })
 
@@ -136,12 +124,8 @@ describe('Image Dimensions', () => {
         availableWidth: 80,
       })
 
-      // With 200x100 image (2:1), scaling to fit 80 width
-      // Display width should be reasonable portion of available
-      expect(result.width).toBeLessThanOrEqual(80)
-      expect(result.width).toBeGreaterThan(0)
-      // Height adjusted for terminal cell aspect ratio
-      expect(result.height).toBeGreaterThan(0)
+      // 200x100 @ 80: ceil(200/15)=14 cells wide, floor(14/2/2)=3 tall
+      expect(result).toEqual({ width: 14, height: 3 })
     })
 
     test('should scale tall image appropriately', () => {
@@ -151,9 +135,7 @@ describe('Image Dimensions', () => {
         availableWidth: 80,
       })
 
-      expect(result.width).toBeLessThanOrEqual(80)
-      expect(result.width).toBeGreaterThan(0)
-      expect(result.height).toBeGreaterThan(0)
+      expect(result).toEqual({ width: 7, height: 7 })
       // Tall images should have larger height relative to width
       expect(result.height).toBeGreaterThanOrEqual(
         result.width / CELL_ASPECT_RATIO,
@@ -167,9 +149,7 @@ describe('Image Dimensions', () => {
         availableWidth: 80,
       })
 
-      expect(result.width).toBeLessThanOrEqual(80)
-      expect(result.width).toBeGreaterThan(0)
-      expect(result.height).toBeGreaterThan(0)
+      expect(result).toEqual({ width: 10, height: 5 })
     })
 
     test('should use fallback when dimensions are not provided', () => {


### PR DESCRIPTION
Follow-up after PR 51 merged at 1083bff. Isolates direnv, chat-history, and image-dimension tests from process-wide logger mocks so bun test-cli cannot steal a pinned dest. Adds resetDirenvStateForTests and restores project root after image temp dirs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/52)
<!-- Reviewable:end -->
