### PR TITLE
Disable chat idle sheen and cheapen precise index deltas

### DIFF
--- a/cli/src/app.tsx
+++ b/cli/src/app.tsx
@@ -6,7 +6,6 @@ import { ChatHistoryScreen } from './components/chat-history-screen'
 import { ProjectPickerScreen } from './components/project-picker-screen'
 import { TerminalLink } from './components/terminal-link'
 import { useLogo } from './hooks/use-logo'
-import { useSheenAnimation } from './hooks/use-sheen-animation'
 import { useTerminalDimensions } from './hooks/use-terminal-dimensions'
 import { useTerminalFocus } from './hooks/use-terminal-focus'
 import { useTheme } from './hooks/use-theme'
@@ -45,27 +44,16 @@ export const App = ({
   showProjectPicker,
   onProjectChange,
 }: AppProps) => {
-  const { contentMaxWidth, terminalWidth } = useTerminalDimensions()
+  const { contentMaxWidth } = useTerminalDimensions()
   const theme = useTheme()
 
-  // Sheen animation state for the logo
-  const [sheenPosition, setSheenPosition] = useState(0)
   const blockColor = getLogoBlockColor(theme.name)
   const accentColor = getLogoAccentColor(theme.name)
-  const { applySheenToChar } = useSheenAnimation({
-    logoColor: theme.foreground,
-    accentColor,
-    blockColor,
-    terminalWidth,
-    sheenPosition,
-    setSheenPosition,
-  })
 
   const { component: logoComponent } = useLogo({
     availableWidth: contentMaxWidth,
     accentColor,
     blockColor,
-    applySheenToChar,
   })
 
   const inputRef = useRef<MultilineInputHandle | null>(null)

--- a/cli/src/chat.tsx
+++ b/cli/src/chat.tsx
@@ -67,6 +67,11 @@ import {
   setupOpenbuffProviderFromArgs,
 } from './utils/openbuff-provider'
 import { getDiffStats, type DiffStats } from './utils/git'
+import {
+  peekIndexStatus,
+  shouldForceStatusLineForIndex,
+  type IndexStatusPeek,
+} from './utils/index-status'
 
 import {
   type ChatKeyboardState,
@@ -390,6 +395,7 @@ export const Chat = ({
   // onTotalCost callbacks). Model name + git diff-stats for the status bar.
   const [sessionCostCents, setSessionCostCents] = useState<number>(0)
   const [diffStats, setDiffStats] = useState<DiffStats | null>(null)
+  const [indexStatus, setIndexStatus] = useState<IndexStatusPeek>(null)
 
   // Resolve the model name for the active agent mode from the provider config.
   const modelName = useMemo(() => {
@@ -413,6 +419,15 @@ export const Chat = ({
       setDiffStats(getDiffStats({ cwd }))
     }
   }, [isStreaming])
+
+  // Peek index status from the existing singleton (~2s). getStatus() may
+  // schedule an age-stale refresh; do not call ensureBuilt() from the UI.
+  useEffect(() => {
+    const refresh = () => setIndexStatus(peekIndexStatus())
+    refresh()
+    const interval = setInterval(refresh, 2_000)
+    return () => clearInterval(interval)
+  }, [])
 
   // When streaming completes, flush any pending bash commands into history (ghost mode only)
   // Non-ghost mode commands are already in history and will be cleared when user sends next message
@@ -1470,7 +1485,10 @@ export const Chat = ({
 
   const shouldShowStatusLine =
     !feedbackMode &&
-    (hasStatusIndicatorContent || shouldShowQueuePreview || !isAtBottom)
+    (hasStatusIndicatorContent ||
+      shouldShowQueuePreview ||
+      shouldForceStatusLineForIndex(indexStatus) ||
+      !isAtBottom)
 
   const handleCloseModelRoutePicker = useCallback(() => {
     setModelRoutePickerOpen(false)
@@ -1720,6 +1738,7 @@ export const Chat = ({
             sessionCostCents={sessionCostCents}
             modelName={modelName}
             diffStats={diffStats}
+            indexStatus={indexStatus}
             onStop={chatKeyboardHandlers.onInterruptStream}
           />
         )}

--- a/cli/src/components/project-picker-screen.tsx
+++ b/cli/src/components/project-picker-screen.tsx
@@ -196,6 +196,7 @@ export const ProjectPickerScreen: React.FC<ProjectPickerScreenProps> = ({
     terminalWidth,
     sheenPosition,
     setSheenPosition,
+    enabled: canShowLogo,
   })
 
   const { component: logoComponent } = useLogo({

--- a/cli/src/components/status-bar.tsx
+++ b/cli/src/components/status-bar.tsx
@@ -7,6 +7,10 @@ import { ShimmerText } from './shimmer-text'
 
 import { useTheme } from '../hooks/use-theme'
 import { formatElapsedTime } from '../utils/format-elapsed-time'
+import {
+  formatIndexStatusChip,
+  type IndexStatusPeek,
+} from '../utils/index-status'
 import type { StatusIndicatorState } from '../utils/status-indicator-state'
 
 /** A small status-bar action button with hover-bold styling. */
@@ -62,6 +66,8 @@ interface StatusBarProps {
   modelName?: string | null
   /** Git working-tree diff stats (modified/added/deleted counts). */
   diffStats?: { modified: number; added: number; deleted: number } | null
+  /** Compact index readiness chip from the CLI IndexManager singleton. */
+  indexStatus?: IndexStatusPeek
   onStop?: () => void
 }
 
@@ -74,6 +80,7 @@ export const StatusBar = ({
   sessionCostCents,
   modelName,
   diffStats,
+  indexStatus,
   onStop,
 }: StatusBarProps) => {
   const theme = useTheme()
@@ -229,12 +236,27 @@ export const StatusBar = ({
     return <span fg={theme.secondary}>{`git ${parts.join(' ')}`}</span>
   }
 
+  const renderIndexStatus = () => {
+    const chip = formatIndexStatusChip(indexStatus ?? null)
+    if (!chip) {
+      return null
+    }
+    const fg =
+      chip.tone === 'error'
+        ? theme.error
+        : chip.tone === 'warning'
+          ? theme.warning
+          : theme.secondary
+    return <span fg={fg}>{chip.label}</span>
+  }
+
   const statusIndicatorContent = renderStatusIndicator()
   const elapsedTimeContent = renderElapsedTime()
   const contextWindowContent = renderContextWindowUsage()
   const sessionCostContent = renderSessionCost()
   const modelNameContent = renderModelName()
   const diffStatsContent = renderDiffStats()
+  const indexStatusContent = renderIndexStatus()
 
   const hasContent =
     statusIndicatorContent ||
@@ -242,7 +264,8 @@ export const StatusBar = ({
     contextWindowContent ||
     sessionCostContent ||
     modelNameContent ||
-    diffStatsContent
+    diffStatsContent ||
+    indexStatusContent
 
   return (
     <box
@@ -284,6 +307,7 @@ export const StatusBar = ({
         <text style={{ wrapMode: 'none' }}>{contextWindowContent}</text>
         <text style={{ wrapMode: 'none' }}>{sessionCostContent}</text>
         <text style={{ wrapMode: 'none' }}>{diffStatsContent}</text>
+        <text style={{ wrapMode: 'none' }}>{indexStatusContent}</text>
         <text style={{ wrapMode: 'none' }}>{modelNameContent}</text>
         <text style={{ wrapMode: 'none' }}>{elapsedTimeContent}</text>
         {onStop &&

--- a/cli/src/hooks/__tests__/use-sheen-animation.test.ts
+++ b/cli/src/hooks/__tests__/use-sheen-animation.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
+import React from 'react'
+
+import { SHEEN_INTERVAL_MS } from '../../components/logo-constants'
+import { useSheenAnimation } from '../use-sheen-animation'
+
+/**
+ * Tests for useSheenAnimation hook
+ *
+ * NOTE: Tests install a minimal React dispatcher so hooks can run without a renderer.
+ */
+
+describe('useSheenAnimation', () => {
+  type ReactInternals = {
+    H: {
+      useState: <T>(value: T) => [T, () => void]
+      useCallback: <T>(callback: T) => T
+      useEffect: (effect: () => void | (() => void)) => void
+    }
+  }
+  const reactInternals = (
+    React as unknown as {
+      __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE: ReactInternals
+    }
+  ).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE
+  let originalSetInterval: typeof setInterval
+  let originalClearInterval: typeof clearInterval
+  let intervals: { id: number; ms: number; fn: () => void; cleared: boolean }[]
+  let nextId: number
+  let originalDispatcher: ReactInternals['H'] | undefined
+
+  beforeEach(() => {
+    originalDispatcher = reactInternals.H
+    reactInternals.H = {
+      useState: <T>(value: T) => [value, () => {}],
+      useCallback: <T>(callback: T) => callback,
+      useEffect: (effect: () => void | (() => void)) => {
+        effect()
+      },
+    }
+
+    intervals = []
+    nextId = 1
+    originalSetInterval = globalThis.setInterval
+    originalClearInterval = globalThis.clearInterval
+
+    globalThis.setInterval = ((fn: () => void, ms?: number) => {
+      const id = nextId++
+      intervals.push({ id, ms: Number(ms ?? 0), fn, cleared: false })
+      return id as unknown as ReturnType<typeof setInterval>
+    }) as typeof setInterval
+
+    globalThis.clearInterval = ((id?: ReturnType<typeof clearInterval>) => {
+      const interval = intervals.find((t) => t.id === (id as unknown as number))
+      if (interval) interval.cleared = true
+    }) as typeof clearInterval
+  })
+
+  afterEach(() => {
+    reactInternals.H = originalDispatcher!
+    globalThis.setInterval = originalSetInterval
+    globalThis.clearInterval = originalClearInterval
+  })
+
+  const baseParams = {
+    logoColor: '#fff',
+    accentColor: '#9EFC62',
+    blockColor: '#ffffff',
+    terminalWidth: 80,
+    sheenPosition: 0,
+  }
+
+  test('enabled: true schedules one interval at SHEEN_INTERVAL_MS', () => {
+    const setSheenPosition = mock(() => {})
+
+    useSheenAnimation({
+      ...baseParams,
+      setSheenPosition,
+      enabled: true,
+    })
+
+    expect(intervals.length).toBe(1)
+    expect(intervals[0].ms).toBe(SHEEN_INTERVAL_MS)
+  })
+
+  test('enabled: false schedules no interval and never calls setSheenPosition', () => {
+    const setSheenPosition = mock(() => {})
+
+    useSheenAnimation({
+      ...baseParams,
+      setSheenPosition,
+      enabled: false,
+    })
+
+    expect(intervals.length).toBe(0)
+    expect(setSheenPosition).not.toHaveBeenCalled()
+  })
+})

--- a/cli/src/hooks/use-sheen-animation.tsx
+++ b/cli/src/hooks/use-sheen-animation.tsx
@@ -14,6 +14,7 @@ interface UseSheenAnimationParams {
   terminalWidth: number | undefined
   sheenPosition: number
   setSheenPosition: (value: number | ((prev: number) => number)) => void
+  enabled?: boolean
 }
 
 export function useSheenAnimation({
@@ -23,10 +24,13 @@ export function useSheenAnimation({
   terminalWidth,
   sheenPosition,
   setSheenPosition,
+  enabled = true,
 }: UseSheenAnimationParams) {
   const [isReversing, setIsReversing] = useState(false)
 
   useEffect(() => {
+    if (!enabled) return
+
     const maxPosition = Math.max(10, Math.min((terminalWidth || 80) - 4, 100))
     const step = SHEEN_STEP
 
@@ -44,7 +48,7 @@ export function useSheenAnimation({
     return () => {
       clearInterval(interval)
     }
-  }, [terminalWidth, setSheenPosition])
+  }, [enabled, terminalWidth, setSheenPosition])
 
   const applySheenToChar = useCallback(
     (char: string, charIndex: number) => {

--- a/cli/src/utils/__tests__/index-status.test.ts
+++ b/cli/src/utils/__tests__/index-status.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatIndexStatusChip,
+  shouldForceStatusLineForIndex,
+} from '../index-status'
+
+describe('formatIndexStatusChip', () => {
+  test('hides the chip when status is missing, disabled, or empty', () => {
+    expect(formatIndexStatusChip(null)).toBeNull()
+    expect(
+      formatIndexStatusChip({ state: 'disabled', refreshing: false }),
+    ).toBeNull()
+    expect(
+      formatIndexStatusChip({ state: 'empty', refreshing: false }),
+    ).toBeNull()
+  })
+
+  test('shows building even when a refresh is also in flight', () => {
+    expect(
+      formatIndexStatusChip({ state: 'building', refreshing: true }),
+    ).toEqual({
+      label: 'idx building',
+      tone: 'warning',
+    })
+    expect(
+      formatIndexStatusChip({ state: 'building', refreshing: false }),
+    ).toEqual({
+      label: 'idx building',
+      tone: 'warning',
+    })
+  })
+
+  test('shows refreshing when a snapshot exists and a refresh is running', () => {
+    expect(
+      formatIndexStatusChip({ state: 'ready', refreshing: true }),
+    ).toEqual({
+      label: 'idx refreshing',
+      tone: 'warning',
+    })
+    expect(
+      formatIndexStatusChip({ state: 'degraded', refreshing: true }),
+    ).toEqual({
+      label: 'idx refreshing',
+      tone: 'warning',
+    })
+  })
+
+  test('shows stale, failed, and ready chips', () => {
+    expect(
+      formatIndexStatusChip({ state: 'stale', refreshing: false }),
+    ).toEqual({
+      label: 'idx stale',
+      tone: 'warning',
+    })
+    expect(
+      formatIndexStatusChip({ state: 'failed', refreshing: false }),
+    ).toEqual({
+      label: 'idx failed',
+      tone: 'error',
+    })
+    expect(
+      formatIndexStatusChip({ state: 'ready', refreshing: false }),
+    ).toEqual({
+      label: 'idx ready',
+      tone: 'secondary',
+    })
+    expect(
+      formatIndexStatusChip({ state: 'degraded', refreshing: false }),
+    ).toEqual({
+      label: 'idx ready',
+      tone: 'secondary',
+    })
+  })
+})
+
+describe('shouldForceStatusLineForIndex', () => {
+  test('keeps the status line open for building, refreshing, and failed', () => {
+    expect(
+      shouldForceStatusLineForIndex({ state: 'building', refreshing: false }),
+    ).toBe(true)
+    expect(
+      shouldForceStatusLineForIndex({ state: 'ready', refreshing: true }),
+    ).toBe(true)
+    expect(
+      shouldForceStatusLineForIndex({ state: 'failed', refreshing: false }),
+    ).toBe(true)
+  })
+
+  test('does not force the status line for a quiet ready chip', () => {
+    expect(shouldForceStatusLineForIndex(null)).toBe(false)
+    expect(
+      shouldForceStatusLineForIndex({ state: 'ready', refreshing: false }),
+    ).toBe(false)
+    expect(
+      shouldForceStatusLineForIndex({ state: 'stale', refreshing: false }),
+    ).toBe(false)
+  })
+})

--- a/cli/src/utils/index-status.ts
+++ b/cli/src/utils/index-status.ts
@@ -1,0 +1,67 @@
+import { IndexManager } from '@codebuff/indexer'
+import { loadProviderConfigSync } from '@openbuff/sdk'
+
+import { getProjectRoot } from '../project-files'
+
+export type IndexStatusChip = {
+  label: string
+  tone: 'secondary' | 'warning' | 'error'
+} | null
+
+export type IndexStatusPeek = {
+  state: string
+  refreshing: boolean
+} | null
+
+/** Peek the CLI index singleton without constructing an embedder. */
+export function peekIndexStatus(): IndexStatusPeek {
+  try {
+    const indexing = loadProviderConfigSync().config.indexing
+    if (indexing.enabled === false) return null
+    const status = IndexManager.getInstance(
+      getProjectRoot(),
+      indexing,
+    ).getStatus()
+    if (status.state === 'disabled') return null
+    return {
+      state: status.state,
+      refreshing: status.refreshing,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function formatIndexStatusChip(
+  status: { state: string; refreshing: boolean } | null,
+): IndexStatusChip {
+  if (!status) return null
+  if (status.state === 'disabled' || status.state === 'empty') return null
+  if (status.state === 'failed') {
+    return { label: 'idx failed', tone: 'error' }
+  }
+  if (status.state === 'building') {
+    return { label: 'idx building', tone: 'warning' }
+  }
+  if (status.refreshing) {
+    return { label: 'idx refreshing', tone: 'warning' }
+  }
+  if (status.state === 'stale') {
+    return { label: 'idx stale', tone: 'warning' }
+  }
+  if (status.state === 'ready' || status.state === 'degraded') {
+    return { label: 'idx ready', tone: 'secondary' }
+  }
+  return null
+}
+
+export function shouldForceStatusLineForIndex(
+  status: { state: string; refreshing: boolean } | null,
+): boolean {
+  if (!status) return false
+  return (
+    status.state === 'building' ||
+    status.state === 'failed' ||
+    status.refreshing
+  )
+}

--- a/packages/indexer/src/file-walker.test.ts
+++ b/packages/indexer/src/file-walker.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   BINARY_EXTENSIONS,
   normalizeRelativePath,
+  statProjectFiles,
   walkProject,
   walkProjectDetailed,
 } from './file-walker'
@@ -320,5 +321,115 @@ describe('file-walker walkProject', () => {
     )
     const files = await walkProject(root)
     expect(files).toEqual([])
+  })
+})
+
+describe('file-walker statProjectFiles', () => {
+  test('stats only the requested paths and applies walker filters', async () => {
+    const root = await makeTempProject({
+      'src/keep.ts': 'export const keep = true\n',
+      'src/missing-neighbor.ts': 'export const gone = true\n',
+      'assets/player.png': '\x89PNG fake binary\n',
+      'assets/model.fbx': 'binary fbx data\n',
+      '.env': 'TOKEN=secret\n',
+      '.agents/sessions/a/findings.md': 'stale audit\n',
+    })
+    await fs.promises.unlink(path.join(root, 'src/missing-neighbor.ts'))
+
+    const files = await statProjectFiles(root, [
+      'src/keep.ts',
+      'src/missing-neighbor.ts',
+      'assets/player.png',
+      'assets/model.fbx',
+      '.env',
+      '.agents/sessions/a/findings.md',
+      'src/does-not-exist.ts',
+    ])
+    const relPaths = files.map((file) => file.relativePath)
+    expect(relPaths).toEqual(['src/keep.ts', 'assets/model.fbx'])
+    expect(
+      files.find((file) => file.relativePath === 'assets/model.fbx')?.asset,
+    ).toEqual({
+      kind: '3d',
+      format: 'fbx',
+    })
+  })
+
+  test('rejects absolute paths and parent-directory segments', async () => {
+    const root = await makeTempProject({
+      'src/keep.ts': 'export const keep = true\n',
+    })
+    const files = await statProjectFiles(root, [
+      '/etc/passwd',
+      '../secret.ts',
+      'src/../../etc/passwd',
+      'src/keep.ts',
+    ])
+    const relPaths = files.map((file) => file.relativePath)
+    expect(relPaths).toEqual(['src/keep.ts'])
+    expect(relPaths).not.toContain('/etc/passwd')
+    expect(relPaths).not.toContain('../secret.ts')
+    expect(relPaths).not.toContain('src/../../etc/passwd')
+  })
+
+  test('honors extraExclude (basename, prefix, and ignore-style globs) and skips gitignored paths', async () => {
+    const root = await makeTempProject({
+      'src/keep.ts': 'export const keep = true\n',
+      'src/skip-me.ts': 'export const skip = true\n',
+      'vendor/lib/hidden.ts': 'export const vendor = true\n',
+      'logs/app.log': 'log line\n',
+      'tmp-data/cache.ts': 'export const cache = true\n',
+      '.gitignore': 'logs/\n',
+      'src/.gitignore': 'skip-me.ts\n',
+      'src/.openbuffignore': 'nested-secret.ts\n',
+      'src/nested-secret.ts': 'export const secret = true\n',
+      '.codebuffignore': '*.tmp.ts\n',
+      'scratch.tmp.ts': 'export const tmp = true\n',
+    })
+
+    const files = await statProjectFiles(
+      root,
+      [
+        'src/keep.ts',
+        'src/skip-me.ts',
+        'vendor/lib/hidden.ts',
+        'logs/app.log',
+        'tmp-data/cache.ts',
+        'src/nested-secret.ts',
+        'scratch.tmp.ts',
+      ],
+      ['vendor', 'tmp-data/', 'scratch.tmp.ts'],
+    )
+    const relPaths = files.map((file) => file.relativePath)
+
+    // Kept: not excluded by basename, prefix, ignore globs, or gitignore.
+    expect(relPaths).toEqual(['src/keep.ts'])
+
+    // Nested gitignore (basename pattern via .gitignore).
+    expect(relPaths).not.toContain('src/skip-me.ts')
+    // Root .gitignore directory pattern.
+    expect(relPaths).not.toContain('logs/app.log')
+    // Nested .openbuffignore.
+    expect(relPaths).not.toContain('src/nested-secret.ts')
+    // Root .codebuffignore glob (also listed in extraExclude).
+    expect(relPaths).not.toContain('scratch.tmp.ts')
+    // extraExclude basename / prefix (same policy as walkProjectDetailed).
+    expect(relPaths).not.toContain('vendor/lib/hidden.ts')
+    expect(relPaths).not.toContain('tmp-data/cache.ts')
+
+    // Walk agrees on the same exclusion set for these paths.
+    const walked = await walkProject(root, [
+      'vendor',
+      'tmp-data/',
+      'scratch.tmp.ts',
+    ])
+    const walkedPaths = walked.map((file) => file.relativePath)
+    expect(walkedPaths).toContain('src/keep.ts')
+    expect(walkedPaths).not.toContain('src/skip-me.ts')
+    expect(walkedPaths).not.toContain('logs/app.log')
+    expect(walkedPaths).not.toContain('src/nested-secret.ts')
+    expect(walkedPaths).not.toContain('scratch.tmp.ts')
+    expect(walkedPaths).not.toContain('vendor/lib/hidden.ts')
+    expect(walkedPaths).not.toContain('tmp-data/cache.ts')
   })
 })

--- a/packages/indexer/src/file-walker.ts
+++ b/packages/indexer/src/file-walker.ts
@@ -178,6 +178,157 @@ export async function walkProject(
   return (await walkProjectDetailed(projectRoot, extraExclude)).files
 }
 
+type ScopedMatcher = { base: string; matcher: ReturnType<typeof ignore> }
+
+/**
+ * Stat specific relative paths without walking the project tree.
+ * Applies the same exclusion policy and per-file filters as
+ * {@link walkProjectDetailed}: ancestor `.gitignore` / `.openbuffignore` /
+ * `.codebuffignore` patterns, `ignore()`-style `extraExclude` globs,
+ * basename/prefix excludes, default exclude dirs, size/binary/3D, sensitive,
+ * and generated operational artifacts.
+ */
+export async function statProjectFiles(
+  projectRoot: string,
+  relativePaths: string[],
+  extraExclude: string[] = [],
+): Promise<WalkedFile[]> {
+  const normalizedExtraExclude = extraExclude.map((item) =>
+    normalizeRelativePath(item),
+  )
+  const extraExcludeSet = new Set(
+    normalizedExtraExclude.map((item) => item.replace(/\/$/, '')),
+  )
+  // Cache directory matchers across stated paths (O(depth) per unique dir).
+  const directoryMatcherCache = new Map<string, ScopedMatcher>()
+  const results: WalkedFile[] = []
+  for (const rawPath of relativePaths) {
+    const relativePath = normalizeRelativePath(rawPath).replace(/^\.\//, '')
+    if (!relativePath) continue
+    if (
+      path.isAbsolute(rawPath) ||
+      path.isAbsolute(relativePath) ||
+      relativePath.startsWith('/') ||
+      relativePath.split('/').includes('..')
+    ) {
+      continue
+    }
+    if (
+      isMandatorySensitiveReadPath(relativePath) ||
+      isGeneratedOperationalArtifact(relativePath) ||
+      isExtraExcludedPath(relativePath, extraExcludeSet) ||
+      isIgnoredLikeWalk(
+        projectRoot,
+        relativePath,
+        normalizedExtraExclude,
+        extraExcludeSet,
+        directoryMatcherCache,
+      )
+    ) {
+      continue
+    }
+    const absolutePath = path.join(projectRoot, relativePath)
+    let stat: fs.Stats
+    try {
+      stat = await fs.promises.stat(absolutePath)
+    } catch {
+      continue
+    }
+    if (!stat.isFile()) continue
+    const ext = path.extname(relativePath).toLowerCase()
+    const is3dAsset = THREE_D_ASSET_EXTENSIONS.has(ext)
+    if (stat.size > MAX_FILE_SIZE && !is3dAsset) continue
+    if (BINARY_EXTENSIONS.has(ext) && !is3dAsset) continue
+    results.push({
+      absolutePath,
+      relativePath,
+      ext,
+      mtime: stat.mtimeMs,
+      size: stat.size,
+      ...(is3dAsset
+        ? { asset: { kind: '3d' as const, format: ext.slice(1) } }
+        : {}),
+    })
+  }
+  return results
+}
+
+function isExtraExcludedPath(
+  relativePath: string,
+  extraExcludeSet: Set<string>,
+): boolean {
+  const segments = relativePath.split('/')
+  for (const exclude of extraExcludeSet) {
+    if (!exclude) continue
+    if (relativePath === exclude || relativePath.startsWith(`${exclude}/`)) {
+      return true
+    }
+    if (!exclude.includes('/') && segments.includes(exclude)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Apply walkProjectDetailed ignore semantics for a single relative path:
+ * load ancestor ignore files from projectRoot (O(depth), no tree walk) and
+ * evaluate `ignore()` matchers the same way the recursive walk does.
+ */
+function isIgnoredLikeWalk(
+  projectRoot: string,
+  relativePath: string,
+  extraExclude: string[],
+  extraExcludeSet: Set<string>,
+  directoryMatcherCache: Map<string, ScopedMatcher>,
+): boolean {
+  const segments = relativePath.split('/').filter(Boolean)
+  if (segments.length === 0) return true
+
+  let currentAbs = projectRoot
+  const parents: ScopedMatcher[] = []
+
+  for (let i = 0; i < segments.length; i++) {
+    const name = segments[i]!
+    const isLast = i === segments.length - 1
+
+    if (!isLast) {
+      if (DEFAULT_EXCLUDE_DIRS.has(name) || extraExcludeSet.has(name)) {
+        return true
+      }
+    }
+
+    let directoryMatcher = directoryMatcherCache.get(currentAbs)
+    if (!directoryMatcher) {
+      directoryMatcher = {
+        base: currentAbs,
+        matcher: ignore().add([
+          ...loadIgnorePatterns(path.join(currentAbs, '.gitignore')),
+          ...loadIgnorePatterns(path.join(currentAbs, '.openbuffignore')),
+          ...loadIgnorePatterns(path.join(currentAbs, '.codebuffignore')),
+          ...(currentAbs === projectRoot ? extraExclude : []),
+        ]),
+      }
+      directoryMatcherCache.set(currentAbs, directoryMatcher)
+    }
+
+    const matchers = [...parents, directoryMatcher]
+    const abs = path.join(currentAbs, name)
+    const ignored = matchers.some(({ base, matcher }) => {
+      const scoped = normalizeRelativePath(path.relative(base, abs))
+      return scoped && matcher.ignores(isLast ? scoped : `${scoped}/`)
+    })
+    if (ignored) return true
+
+    if (!isLast) {
+      parents.push(directoryMatcher)
+      currentAbs = abs
+    }
+  }
+
+  return false
+}
+
 export async function walkProjectDetailed(
   projectRoot: string,
   extraExclude: string[] = [],

--- a/packages/indexer/src/metadata-indexer.test.ts
+++ b/packages/indexer/src/metadata-indexer.test.ts
@@ -156,6 +156,146 @@ describe('metadata indexer', () => {
     )
   })
 
+  test('complete mutation delta does not walk the full project tree', async () => {
+    const root = await makeTempProject({
+      'docs/target.md': '# Target\n\nold target\n',
+      'docs/other.md': '# Other\n\nother\n',
+    })
+    const first = await buildMetadataIndex(root)
+    await fs.promises.writeFile(
+      path.join(root, 'docs/target.md'),
+      '# Target\n\nnew target\n',
+    )
+
+    const readdirSpy = spyOn(fs.promises, 'readdir')
+    try {
+      const precise = await updateMetadataIndex(
+        first,
+        root,
+        {},
+        {
+          changedPaths: ['docs/target.md'],
+          complete: true,
+        },
+      )
+      expect(readdirSpy).not.toHaveBeenCalled()
+      expect(precise.files['docs/target.md']?.hash).not.toBe(
+        first.files['docs/target.md']?.hash,
+      )
+      expect(precise.files['docs/other.md']?.hash).toBe(
+        first.files['docs/other.md']?.hash,
+      )
+      expect(precise.coverage?.truncated).toBe(first.coverage?.truncated)
+      expect(precise.coverage?.skippedFiles).toBe(first.coverage?.skippedFiles)
+      expect(precise.coverage?.skippedPrefixes).toEqual(
+        first.coverage?.skippedPrefixes,
+      )
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  test('complete:true delta indexes a newly created path without readdir and does not absorb a sibling omitted from changedPaths', async () => {
+    const root = await makeTempProject({
+      'docs/existing.md': '# Existing\n\nkeep\n',
+    })
+    const first = await buildMetadataIndex(root)
+    expect(first.files['docs/existing.md']).toBeDefined()
+    expect(first.files['docs/created.md']).toBeUndefined()
+    expect(first.files['docs/sibling-new.md']).toBeUndefined()
+
+    await fs.promises.writeFile(
+      path.join(root, 'docs/created.md'),
+      '# Created\n\nnew file content\n',
+      'utf8',
+    )
+    await fs.promises.writeFile(
+      path.join(root, 'docs/sibling-new.md'),
+      '# Sibling\n\nomitted from delta\n',
+      'utf8',
+    )
+
+    const readdirSpy = spyOn(fs.promises, 'readdir')
+    try {
+      const precise = await updateMetadataIndex(
+        first,
+        root,
+        {},
+        {
+          changedPaths: ['docs/created.md'],
+          complete: true,
+        },
+      )
+      expect(readdirSpy).not.toHaveBeenCalled()
+      expect(precise.files['docs/created.md']).toBeDefined()
+      expect(precise.files['docs/created.md']?.hash).toHaveLength(64)
+      expect(precise.files['docs/created.md']?.headings).toContain('Created')
+      // Sibling created on disk but omitted from changedPaths must not be absorbed.
+      expect(precise.files['docs/sibling-new.md']).toBeUndefined()
+      expect(precise.files['docs/existing.md']?.hash).toBe(
+        first.files['docs/existing.md']?.hash,
+      )
+    } finally {
+      readdirSpy.mockRestore()
+    }
+  })
+
+  test('complete:true delta refuses to index a newly created gitignored path', async () => {
+    const root = await makeTempProject({
+      'docs/keep.md': '# Keep\n\nvisible\n',
+      '.gitignore': 'secrets/\n',
+    })
+    const first = await buildMetadataIndex(root)
+    expect(first.files['docs/keep.md']).toBeDefined()
+
+    await fs.promises.mkdir(path.join(root, 'secrets'), { recursive: true })
+    await fs.promises.writeFile(
+      path.join(root, 'secrets/token.md'),
+      '# Token\n\nuser-ignored secret\n',
+      'utf8',
+    )
+
+    const precise = await updateMetadataIndex(
+      first,
+      root,
+      {},
+      {
+        changedPaths: ['secrets/token.md'],
+        complete: true,
+      },
+    )
+    expect(precise.files['secrets/token.md']).toBeUndefined()
+    expect(precise.files['docs/keep.md']).toBeDefined()
+  })
+
+  test('complete mutation delta removes a previously indexed path that now fails walker filters', async () => {
+    const root = await makeTempProject({
+      'docs/keep.md': '# Keep\n\nkeep me\n',
+      'docs/grow.md': '# Grow\n\nsmall\n',
+    })
+    const first = await buildMetadataIndex(root)
+    expect(first.files['docs/grow.md']).toBeDefined()
+    expect(first.files['docs/keep.md']).toBeDefined()
+
+    await fs.promises.writeFile(
+      path.join(root, 'docs/grow.md'),
+      'x'.repeat(500_001),
+    )
+    const updated = await updateMetadataIndex(
+      first,
+      root,
+      {},
+      {
+        changedPaths: ['docs/grow.md'],
+        complete: true,
+      },
+    )
+    expect(updated.files['docs/grow.md']).toBeUndefined()
+    expect(updated.graph.nodes['file:docs/grow.md']).toBeUndefined()
+    expect(updated.files['docs/keep.md']).toBeDefined()
+    expect(updated.graph.nodes['file:docs/keep.md']).toBeDefined()
+  })
+
   test('drops stale metadata when a walked file cannot be read during incremental hashing', async () => {
     const root = await makeTempProject({
       'docs/a.md': '# Alpha\n\nalpha topic\n',

--- a/packages/indexer/src/metadata-indexer.ts
+++ b/packages/indexer/src/metadata-indexer.ts
@@ -7,7 +7,11 @@ import {
   SUPPORTED_CODE_EXTENSIONS,
 } from '@codebuff/code-map'
 
-import { BINARY_EXTENSIONS, walkProjectDetailed } from './file-walker'
+import {
+  BINARY_EXTENSIONS,
+  statProjectFiles,
+  walkProjectDetailed,
+} from './file-walker'
 import {
   buildGuidToPathMap,
   extractAssetRefs,
@@ -27,7 +31,8 @@ import type {
   ParseDiagnostic,
 } from './types'
 import type { ParseCoverage, ParsedFileTokens } from '@codebuff/code-map'
-import type { WalkProjectResult } from './file-walker'
+import type { WalkedFile, WalkProjectResult } from './file-walker'
+
 
 const CODE_EXTENSIONS = new Set(SUPPORTED_CODE_EXTENSIONS)
 
@@ -179,14 +184,16 @@ export async function updateMetadataIndex(
   mutationDelta?: IndexMutationDelta,
 ): Promise<MetadataIndex> {
   tsAliasCacheByRoot.delete(projectRoot)
-  const walked = await walkProjectDetailed(
-    projectRoot,
-    getIndexExcludes(config),
-    config.maxFiles,
-  )
+  const preciseDelta = mutationDelta?.complete === true
+  const walked = preciseDelta
+    ? await collectPreciseWalk(existing, projectRoot, mutationDelta, config)
+    : await walkProjectDetailed(
+        projectRoot,
+        getIndexExcludes(config),
+        config.maxFiles,
+      )
   const files = walked.files
   const currentByPath = new Map(files.map((f) => [f.relativePath, f]))
-  const preciseDelta = mutationDelta?.complete === true
   const changedDeltaPaths = new Set(
     (mutationDelta?.changedPaths ?? []).map(normalizeMutationPath),
   )
@@ -544,6 +551,74 @@ function createIndexCoverage(
     skippedFiles: walked.skippedFiles,
     skippedPrefixes: walked.skippedPrefixes,
     parser,
+  }
+}
+
+async function collectPreciseWalk(
+  existing: MetadataIndex,
+  projectRoot: string,
+  mutationDelta: IndexMutationDelta,
+  config: IndexingConfig,
+): Promise<WalkProjectResult> {
+  const deletedPaths = new Set(
+    (mutationDelta.deletedPaths ?? []).map(normalizeMutationPath),
+  )
+  const changedPaths = (mutationDelta.changedPaths ?? []).map(
+    normalizeMutationPath,
+  )
+  const changedPathSet = new Set(changedPaths)
+  const stated = await statProjectFiles(
+    projectRoot,
+    changedPaths,
+    getIndexExcludes(config),
+  )
+  const statedByPath = new Map(
+    stated.map((file) => [file.relativePath, file]),
+  )
+
+  const files: WalkedFile[] = []
+  for (const [relativePath, indexed] of Object.entries(existing.files)) {
+    if (deletedPaths.has(relativePath)) continue
+    const overlay = statedByPath.get(relativePath)
+    if (overlay) {
+      files.push(overlay)
+      continue
+    }
+    // Invariant: changedPaths without a successful stat overlay must be omitted
+    // so updateMetadataIndex can add them to deletedPaths.
+    if (changedPathSet.has(relativePath)) continue
+    files.push(walkedFileFromIndexed(projectRoot, indexed))
+  }
+
+  for (const file of stated) {
+    if (!existing.files[file.relativePath] && !deletedPaths.has(file.relativePath)) {
+      files.push(file)
+    }
+  }
+
+  const coverage = existing.coverage
+  return {
+    files,
+    truncated: coverage?.truncated ?? false,
+    maxFiles: coverage?.maxFiles ?? config.maxFiles ?? 20_000,
+    skippedFiles: coverage?.skippedFiles ?? 0,
+    skippedPrefixes: coverage?.skippedPrefixes ?? [],
+  }
+}
+
+function walkedFileFromIndexed(
+  projectRoot: string,
+  indexed: IndexedFile,
+): WalkedFile {
+  return {
+    absolutePath: path.join(projectRoot, indexed.path),
+    relativePath: indexed.path,
+    ext: indexed.ext,
+    mtime: indexed.mtime,
+    size: indexed.size,
+    ...(indexed.asset
+      ? { asset: { kind: '3d' as const, format: indexed.asset.format } }
+      : {}),
   }
 }
 


### PR DESCRIPTION
Turn off logo sheen animation while chatting to cut idle CPU, and use statProjectFiles for complete mutation deltas so index updates reuse the same ignore policy as walk without a full tree walk. Surface index readiness as a status-bar chip so building/refresh/failure states stay visible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/55)
<!-- Reviewable:end -->
