### PR TITLE
Align test-writer and doc-writer to edit_transaction only

### DIFF
--- a/agents/__tests__/base2.test.ts
+++ b/agents/__tests__/base2.test.ts
@@ -615,9 +615,21 @@ describe('base2 validation/reviewer coordination prompts', () => {
       'if the suggest_followups tool is available',
     )
     expect(base2.instructionsPrompt).toContain(
+      'absolute last tool in the same final message after the single completion summary',
+    )
+    expect(base2.instructionsPrompt).toContain(
+      'if committing, spawn git-committer before suggest_followups',
+    )
+    expect(base2.instructionsPrompt).toContain(
+      'never mid-turn and never before remaining work',
+    )
+    expect(base2.instructionsPrompt).toContain(
       'If suggest_followups is unavailable, still provide the final summary/end normally',
     )
     expect(base2.stepPrompt).toContain('if that tool is available')
+    expect(base2.stepPrompt).toContain(
+      'absolute last tool in that same final message',
+    )
     expect(base2.stepPrompt).toContain(
       'If suggest_followups is unavailable, do not let that block the final summary/end',
     )

--- a/agents/__tests__/new-bundled-agents.test.ts
+++ b/agents/__tests__/new-bundled-agents.test.ts
@@ -78,10 +78,15 @@ describe('new bundled agents (M2.6)', () => {
       expect(testWriter.model).toBeUndefined()
     })
 
-    test('exposes read + write tools but not terminal', () => {
+    test('exposes read + edit_transaction tools but not terminal or standalone writes', () => {
       const tools = testWriter.toolNames ?? []
       expect(tools).toContain('read_files')
-      expect(tools).toContain('write_file')
+      expect(tools).toContain('edit_transaction')
+      expect(tools).toContain('set_output')
+      expect(tools).not.toContain('str_replace')
+      expect(tools).not.toContain('write_file')
+      expect(tools).not.toContain('replace_range')
+      expect(tools).not.toContain('rewrite_symbol')
       expect(tools).not.toContain('run_terminal_command')
     })
 
@@ -140,10 +145,15 @@ describe('new bundled agents (M2.6)', () => {
       expect(docWriter.model).toBeUndefined()
     })
 
-    test('exposes read + write tools but not terminal', () => {
+    test('exposes read + edit_transaction tools but not terminal or standalone writes', () => {
       const tools = docWriter.toolNames ?? []
       expect(tools).toContain('read_files')
-      expect(tools).toContain('str_replace')
+      expect(tools).toContain('edit_transaction')
+      expect(tools).toContain('set_output')
+      expect(tools).not.toContain('str_replace')
+      expect(tools).not.toContain('write_file')
+      expect(tools).not.toContain('replace_range')
+      expect(tools).not.toContain('rewrite_symbol')
       expect(tools).not.toContain('run_terminal_command')
     })
 

--- a/agents/base2/base-deep.ts
+++ b/agents/base2/base-deep.ts
@@ -300,7 +300,7 @@ Make sure to narrate to the user what you are doing and why you are doing it as 
     noAskUser
       ? ''
       : `
-After writing a user-visible completion summary, use suggest_followups to suggest ~3 next steps the user might want to take.`
+After writing a user-visible completion summary (and after git-committer if committing), use suggest_followups as the absolute last tool to suggest ~3 next steps; never mid-turn and never before remaining work.`
   }
 
 ## Followup Requests

--- a/agents/base2/base2.ts
+++ b/agents/base2/base2.ts
@@ -617,6 +617,12 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
       type Base2AgentState = NonNullable<typeof agentState> & {
         base2ActiveWork?: Base2ActiveWorkState
         canSuggestFollowups?: boolean
+        /**
+         * Set by the tool executor after a successful same-step allow-path for
+         * suggest_followups while the gate system is active. Cleared once per
+         * user turn at handleSteps start so a new turn can suggest again.
+         */
+        suggestFollowupsEmitted?: boolean
         uncommittedUnvalidatedFiles?: string[]
         /**
          * Progressive tool-disclosure tiers beyond CORE currently unlocked
@@ -652,6 +658,9 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
       }
 
       const mutableAgentState = (agentState ?? {}) as Base2AgentState
+      // Reset once per user turn so a new turn can suggest followups again
+      // after a prior turn's suggest_followups set the executor emitted flag.
+      mutableAgentState.suggestFollowupsEmitted = false
       const agentId = mutableAgentState.agentId
       const configuredHasNoValidation = config?.hasNoValidation
       const configuredPlanOnly = config?.planOnly === true
@@ -727,7 +736,7 @@ ${disclose(specialistRoutingSection, specialistRoutingPointer)}
       // serialized via .toString() and reconstructed with new Function(...),
       // so a module-scope binding would be undefined at reconstruction time.
       const GATE_PASS_FINALIZATION_NOTICE =
-        'Provide your single user-visible completion summary now if you have not already written one this turn; if you already have, add only the follow-up suggestions instead of repeating it. Write at most one completion summary per turn. Do not make more edits unless absolutely necessary; any new edits will rerun the gate.'
+        'Provide your single user-visible completion summary now if you have not already written one this turn; if you already have, add only the follow-up suggestions instead of repeating it. Write at most one completion summary per turn. Call suggest_followups only as the absolute last tool after that summary (and after git-committer if committing this turn); never mid-turn and never before remaining work. Do not make more edits unless absolutely necessary; any new edits will rerun the gate.'
       const existingActiveWorkState = mutableAgentState.base2ActiveWork
       const hadPendingGateFiles =
         !!existingActiveWorkState &&
@@ -7420,7 +7429,7 @@ function hashGateSnapshotDetails(details: string): string {
             [
               'GATE: PASSED',
               `phase: ${state.currentPhase}`,
-              'allowed actions: final summary, suggest_followups, git-committer (with owned_paths)',
+              'allowed actions: final summary, optional git-committer (with owned_paths), then suggest_followups as absolute last tool',
             ].join('\n'),
           )
         }
@@ -8713,8 +8722,8 @@ ${buildArray(
     ? '- Write exactly ONE user-visible completion summary per turn. For edited code, that summary belongs in the final message after the automated validation/reviewer gate has passed — do not write a completion summary before the gate runs. Keep any pre-gate text to brief progress notes, not a summary of the finished work.'
     : '- Inform the user that you have completed the task in one sentence or a few short bullet points.',
   gateActive
-    ? '- After successfully completing an implementation, if the suggest_followups tool is available, use it to suggest ~3 next steps the user might want to take. For edited code, call it only after the automated validation/reviewer gate has passed, in the same final message as your single completion summary. If suggest_followups is unavailable, still provide the final summary/end normally.'
-    : '- After successfully completing an implementation, if the suggest_followups tool is available, use it to suggest ~3 next steps the user might want to take, in the same final message as your completion summary. If suggest_followups is unavailable, still provide the final summary/end normally.',
+    ? '- After successfully completing an implementation, if the suggest_followups tool is available, use it to suggest ~3 next steps the user might want to take. For edited code, call it only after the automated validation/reviewer gate has passed, as the absolute last tool in the same final message after the single completion summary; if committing, spawn git-committer before suggest_followups; never mid-turn and never before remaining work. If suggest_followups is unavailable, still provide the final summary/end normally.'
+    : '- After successfully completing an implementation, if the suggest_followups tool is available, use it to suggest ~3 next steps the user might want to take as the absolute last tool in the same final message after the completion summary; never mid-turn. If suggest_followups is unavailable, still provide the final summary/end normally.',
 ).join('\n')}`
 }
 
@@ -8762,7 +8771,7 @@ function buildImplementationStepPrompt({
     isDefault &&
       'Do not manually spawn code-reviewer for the same edited file set that the automated runtime gate will review. Manual review is only for user-requested extra review or pre-edit/advisory review. Spawn security-reviewer for auth, crypto, secrets, permissions, injection, sandboxing, supply-chain, or production-risk changes.',
     isDefault &&
-      'After the automated validation/reviewer gate has passed for edited code, write your single completion summary and call suggest_followups with around 3 useful next steps in that same final message, if that tool is available. If suggest_followups is unavailable, do not let that block the final summary/end.',
+      'After the automated validation/reviewer gate has passed for edited code, write your single completion summary and call suggest_followups with around 3 useful next steps as the absolute last tool in that same final message (after git-committer if committing), if that tool is available; never mid-turn and never before remaining work. If suggest_followups is unavailable, do not let that block the final summary/end.',
   ).join('\n')
 }
 

--- a/agents/base2/quality-prompt-section.ts
+++ b/agents/base2/quality-prompt-section.ts
@@ -134,7 +134,9 @@ Dirty working-tree files are not the same as pending: only task-related **review
 
 ## After GATE: PASSED
 
-- Spawn \`git-committer\` only with \`params.owned_paths\` for task-owned paths
+- Write the final user-visible completion summary first
+- Spawn optional \`git-committer\` (with \`params.owned_paths\` for task-owned paths) before followups if committing this turn
+- Call \`suggest_followups\` only as the absolute last tool after summary/commit; never mid-turn and never before remaining work
 - Any new edit re-arms on every new edit (back to GATE: PENDING); one more clear cycle is required. Treat early withhold as normal ordering; do not tight-loop committer spawns — wait for GATE: PASSED, then spawn once.`
 
 /**

--- a/agents/doc-writer/doc-writer.ts
+++ b/agents/doc-writer/doc-writer.ts
@@ -98,8 +98,6 @@ const definition: SecretAgentDefinition = {
     'read_outline',
     'read_subtree',
     'edit_transaction',
-    'str_replace',
-    'write_file',
     'set_output',
   ],
   spawnableAgents: [],
@@ -108,11 +106,34 @@ const definition: SecretAgentDefinition = {
 
   instructionsPrompt: `Instructions:
 1. Write only in documentation paths. You may read any file in the repository to verify the contract you are documenting, but never modify source. Prefer the explicitly supplied source_files and the parent's verified source contract as your primary evidence. Do not invent options, flags, or behaviors.
-2. If target_doc_files are given, read them first and update in place (all mutations go through edit_transaction — prefer str_replace edits for targeted changes and create/write_file for new docs). If not given, infer the doc location from neighboring docs (check docs/, README.md, package READMEs).
-3. Match the existing doc style: heading depth, code-fence language tags, tone, and section ordering. Look at an adjacent doc file as a style reference.
-4. Document the public contract: what it does, the inputs/outputs, usage examples, and gotchas. Skip internal implementation details unless the prompt asks for them.
-5. For code comments, document why, not what.
-6. Finish with set_output using the declared schema. Use completionKind=changed when documentation was modified. Use completionKind=noop only when the existing docs already accurately cover every requested contract; then changedFiles must be empty and evidence must name the exact sections/files verified. Use status=completed only when every requested documentation deliverable is satisfied. List exact changedFiles, requirement/acceptance IDs addressed, unresolved items, and any parent-owned validation requests.
+2. If target_doc_files are given, read them first and update in place. If not given, infer the doc location from neighboring docs (check docs/, README.md, package READMEs).
+3. Call only edit_transaction for mutations. str_replace / create / write_file are edit *types inside* the transaction, not standalone tools. Prefer type "str_replace" for targeted updates and type "create" (or "write_file" for a necessary whole-file rewrite) for new docs. Example:
+<codebuff_tool_call>
+{
+  "cb_tool_name": "edit_transaction",
+  "edits": [
+    {
+      "type": "str_replace",
+      "path": "packages/foo/README.md",
+      "replacements": [
+        {
+          "oldString": "## Usage",
+          "newString": "## Usage\n\nCall foo() with the public options documented above."
+        }
+      ]
+    },
+    {
+      "type": "create",
+      "path": "docs/foo.md",
+      "content": "# Foo\n\nPublic contract for foo.\n"
+    }
+  ]
+}
+</codebuff_tool_call>
+4. Match the existing doc style: heading depth, code-fence language tags, tone, and section ordering. Look at an adjacent doc file as a style reference.
+5. Document the public contract: what it does, the inputs/outputs, usage examples, and gotchas. Skip internal implementation details unless the prompt asks for them.
+6. For code comments, document why, not what.
+7. Finish with set_output using the declared schema. Use completionKind=changed when documentation was modified. Use completionKind=noop only when the existing docs already accurately cover every requested contract; then changedFiles must be empty and evidence must name the exact sections/files verified. Use status=completed only when every requested documentation deliverable is satisfied. List exact changedFiles, requirement/acceptance IDs addressed, unresolved items, and any parent-owned validation requests.
 Do not modify source code. Do not add marketing language. Keep examples minimal and runnable.`.trim(),
 
   handleSteps: function* ({ params }) {

--- a/agents/guides/editor-writers-and-repair.md
+++ b/agents/guides/editor-writers-and-repair.md
@@ -21,8 +21,8 @@ Implementation modes that still run the automated validation/reviewer gate use t
 | --- | --- | --- |
 | `editor` | Non-trivial **implementation** edits after discovery. Self-contained handoff only. Mutates via `edit_transaction`. | Validation, basher, review, git, todos, visual smoke, shell cleanup. Parent-only work stays with the orchestrator. |
 | `repair-editor` | **Finding-scoped** fixes: parseable validation diagnostics or stable reviewer finding IDs. Same edit surface as editor plus `read_subtree` for diagnosis. | Unrelated refactors, docs, feature work, or protocol/attestation failures (snapshot mismatch is not a source repair). |
-| `test-writer` | New/extended tests under existing test paths only (`*.test.*`, `*.spec.*`, `__tests__/`, `test/`, `tests/`). Reports `requestedValidation` for the parent/basher. | Production source (except when a test is unobservable without a minimal source change — still not the default). Running terminals itself. |
-| `doc-writer` | Documentation paths only (`docs/**`, `README*`, `**/*.md`, `**/*.mdx`). Verifies against source; never invents API behavior. | Production source edits. |
+| `test-writer` | New/extended tests under existing test paths only (`*.test.*`, `*.spec.*`, `__tests__/`, `test/`, `tests/`). Mutates via `edit_transaction` (use `str_replace` / `create` / `write_file` edit *types* inside the transaction; never as standalone tools). Reports `requestedValidation` for the parent/basher. | Production source (except when a test is unobservable without a minimal source change — still not the default). Running terminals itself. |
+| `doc-writer` | Documentation paths only (`docs/**`, `README*`, `**/*.md`, `**/*.mdx`). Mutates via `edit_transaction` (use `str_replace` / `create` / `write_file` edit *types* inside the transaction; never as standalone tools). Verifies against source; never invents API behavior. | Production source edits. |
 
 All four use structured `set_output` receipts. Writers expose `status`, `completionKind` (`changed` \| `noop`), `changedFiles`, and `evidence`. The runtime accepts writer receipts only when status is `completed` and either:
 

--- a/agents/test-writer/test-writer.ts
+++ b/agents/test-writer/test-writer.ts
@@ -92,8 +92,6 @@ const definition: SecretAgentDefinition = {
     'read_files',
     'read_outline',
     'edit_transaction',
-    'write_file',
-    'str_replace',
     'set_output',
   ],
   spawnableAgents: [],
@@ -107,8 +105,31 @@ Instructions:
 2. Read an existing in-scope test file in the same package to mimic its imports, harness, and assertion style. Do not invent a new test framework.
 3. Write focused tests covering: the happy path, key edge cases (empty/null/zero/boundary), and the specific behavior the prompt asked for. Prefer one assertion concept per test.
 3a. For bug fixes, prefer writing the reproducing failing test before implementation when the orchestrator invokes you in pre-implementation mode.
-4. Do not run terminal commands directly. If a test_command param is provided, include it as the validation command for the parent/basher to run after your changes.
-5. Finish with set_output using the declared schema. Use completionKind=changed when files were modified. Use completionKind=noop only when existing tests already cover every requested behavior; then changedFiles must be empty and evidence must name the exact existing tests/assertions you read. Use status=completed only when every requested test deliverable is satisfied. List exact changedFiles, requirement/acceptance IDs addressed, unresolved items, and the parent-owned requestedValidation commands.
+4. Call only edit_transaction for mutations. str_replace / create / write_file are edit *types inside* the transaction, not standalone tools. Prefer type "str_replace" for targeted updates and type "create" (or "write_file" for a necessary whole-file rewrite) for new test files. Example:
+<codebuff_tool_call>
+{
+  "cb_tool_name": "edit_transaction",
+  "edits": [
+    {
+      "type": "str_replace",
+      "path": "packages/foo/__tests__/bar.test.ts",
+      "replacements": [
+        {
+          "oldString": "describe('bar', () => {",
+          "newString": "describe('bar', () => {\n  test('handles empty input', () => {\n    expect(bar('')).toBe(null)\n  })"
+        }
+      ]
+    },
+    {
+      "type": "create",
+      "path": "packages/foo/__tests__/baz.test.ts",
+      "content": "import { describe, expect, test } from 'bun:test'\n\ndescribe('baz', () => {\n  test('works', () => {\n    expect(true).toBe(true)\n  })\n})\n"
+    }
+  ]
+}
+</codebuff_tool_call>
+5. Do not run terminal commands directly. If a test_command param is provided, include it as the validation command for the parent/basher to run after your changes.
+6. Finish with set_output using the declared schema. Use completionKind=changed when files were modified. Use completionKind=noop only when existing tests already cover every requested behavior; then changedFiles must be empty and evidence must name the exact existing tests/assertions you read. Use status=completed only when every requested test deliverable is satisfied. List exact changedFiles, requirement/acceptance IDs addressed, unresolved items, and the parent-owned requestedValidation commands.
 Do not refactor unrelated tests. Do not modify source code under test — if the source has a bug, report it and stop.`.trim(),
 
   handleSteps: function* () {

--- a/agents/tool-reachability.test.ts
+++ b/agents/tool-reachability.test.ts
@@ -136,6 +136,19 @@ describe('agent tool reachability', () => {
       expect(tools).not.toContain(tool)
   })
 
+  test('test-writer and doc-writer expose edit_transaction without legacy direct edits', () => {
+    for (const definition of [testWriter, docWriter]) {
+      const tools = definition.toolNames ?? []
+      expect(tools).toContain('edit_transaction')
+      for (const tool of LEGACY_DIRECT_EDIT_TOOLS) {
+        expect(
+          tools,
+          `${definition.id} must not expose legacy direct edit tool ${tool}`,
+        ).not.toContain(tool)
+      }
+    }
+  })
+
   test('audit shards receive only derived findings-artifact write authority', () => {
     const definition = createGeneralAgent({ model: 'opus' })
 

--- a/common/src/tools/params/tool/suggest-followups.ts
+++ b/common/src/tools/params/tool/suggest-followups.ts
@@ -45,7 +45,7 @@ const outputSchema = z.object({
 })
 
 const description = `
-Suggest ~3 clickable followup prompts (assistant-executable next steps). Write a brief user-visible summary first so the user is not left with only cards.
+Suggest ~3 clickable followup prompts (assistant-executable next steps). Absolute last actionable tool after a brief user-visible completion summary (and after git-committer if committing this turn); never mid-turn and never before remaining work. Write the summary first so the user is not left with only cards.
 
 Good: alternatives, related features, refactors, unit tests, "Continue with the next step". Avoid: bare commits, vague "test x", or manual user-only testing. Vary from prior suggestions.
 

--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -244,10 +244,11 @@ orchestrator and by explicit subagent calls. Its input schema accepts an
 optional `params.target_files` array and an optional `params.test_command`.
 When `target_files` is present, the agent reads those source files before
 writing tests so it can match the changed public surface and edge cases.
-It is intentionally read/write-only for files plus search/outline tools:
-it does **not** run terminal commands itself. If `test_command` is
-provided, the agent reports that command back for the parent or `basher`
-to run during validation.
+It mutates only through `edit_transaction` (with `str_replace` / `create` /
+`write_file` as edit *types* inside the transaction, not as standalone tools),
+plus read/outline tools. It does **not** run terminal commands itself. If
+`test_command` is provided, the agent reports that command back for the parent
+or `basher` to run during validation.
 
 The agent's prompt contract is narrow: read the changed source, find an
 existing test in the same package, mimic that harness and assertion style,
@@ -1022,14 +1023,15 @@ Example:
 
 ### `edit_transaction` and compatibility edit handlers
 
-Shipped root and editor agents receive `edit_transaction` as their single
-model-visible project mutation tool. Its discriminated edit variants cover
-targeted `str_replace`, `replace_range`, `rewrite_symbol`, unified `patch`,
-structured imports/insertion, create/delete/move, and whole-file `write_file`
-operations. The corresponding standalone handlers remain registered for
-persisted/external compatibility, but their overlapping schemas are not added
-to root/editor provider prompts. Under strict-mode edit flows all variants
-participate in staged read-before-edit enforcement:
+Shipped root, editor, test-writer, and doc-writer agents receive
+`edit_transaction` as their single model-visible project mutation tool. Its
+discriminated edit variants cover targeted `str_replace`, `replace_range`,
+`rewrite_symbol`, unified `patch`, structured imports/insertion,
+create/delete/move, and whole-file `write_file` operations. The corresponding
+standalone handlers remain registered for persisted/external compatibility, but
+their overlapping schemas are not added to those agents' provider prompts.
+Under strict-mode edit flows all variants participate in staged
+read-before-edit enforcement:
 
 - Every edit requires an explicit `type` discriminator. Valid values are
   `str_replace`, `replace_range`, `structured`, `create`, `delete`, `move`,

--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -250,6 +250,30 @@ plus read/outline tools. It does **not** run terminal commands itself. If
 `test_command` is provided, the agent reports that command back for the parent
 or `basher` to run during validation.
 
+Model-visible `edit_transaction` payload shape (tool name `edit_transaction`):
+
+```json
+{
+  "edits": [
+    {
+      "type": "str_replace",
+      "path": "packages/foo/__tests__/bar.test.ts",
+      "replacements": [
+        {
+          "oldString": "describe('bar', () => {",
+          "newString": "describe('bar', () => {\n  test('handles empty input', () => {\n    expect(bar('')).toBe(null)\n  })"
+        }
+      ]
+    },
+    {
+      "type": "create",
+      "path": "packages/foo/__tests__/baz.test.ts",
+      "content": "import { describe, expect, test } from 'bun:test'\n\ndescribe('baz', () => {\n  test('works', () => {\n    expect(true).toBe(true)\n  })\n})\n"
+    }
+  ]
+}
+```
+
 The agent's prompt contract is narrow: read the changed source, find an
 existing test in the same package, mimic that harness and assertion style,
 write focused behavior-oriented tests, and stop rather than modifying the

--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -685,6 +685,20 @@ an agent that provides the capability (for example, spawn `code-searcher` for
 multi-query batch search). Do not retry the same unavailable name — the result
 will not change.
 
+### `suggest_followups` last-action contract
+
+For gate-active agents (`canSuggestFollowups` defined), `suggest_followups` is
+the absolute last actionable tool after the user-visible completion summary
+(and after optional `git-committer` if committing). Never call it mid-turn and
+never before remaining work. After followups, only terminal companions may run:
+`suggest_followups`, `end_turn`, `task_completed`.
+
+Native and custom/MCP paths share `getPostSuggestFollowupsBlockReason` in
+`packages/agent-runtime/src/tools/tool-executor.ts`. `suggestFollowupsEmitted`
+is set on the allow path and cleared at the start of each base2 user turn.
+`GATE: PENDING` still rejects `suggest_followups`. Non-gated agents
+(`canSuggestFollowups` undefined) are unchanged.
+
 ### Background shell jobs (`check_job` / `read_logs` / `kill_job` / `list_jobs`)
 
 Background jobs are unified behind a single `JobRegistry` (in the `common`

--- a/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
+++ b/packages/agent-runtime/src/__tests__/run-agent-step-tools.test.ts
@@ -2186,8 +2186,8 @@ describe('runAgentStep - set_output tool', () => {
     expect(chunks).toContainEqual(
       expect.objectContaining({
         type: 'error',
-        message: expect.stringContaining(
-          'File-changing tools are not available after suggest_followups',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
         ),
       }),
     )
@@ -2244,8 +2244,8 @@ describe('runAgentStep - set_output tool', () => {
     expect(chunks).toContainEqual(
       expect.objectContaining({
         type: 'error',
-        message: expect.stringContaining(
-          'File-changing tools are not available after suggest_followups',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
         ),
       }),
     )
@@ -2255,6 +2255,345 @@ describe('runAgentStep - set_output tool', () => {
         toolName: 'rewrite_symbol',
       }),
     )
+  })
+
+  it('blocks non-file tools after same-step suggest_followups in gated final response steps', async () => {
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+    }
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      yield createToolCallChunk('suggest_followups', {
+        followups: [{ prompt: 'Add tests', label: 'Add tests' }],
+      })
+      yield createToolCallChunk('code_search', {
+        pattern: 'export const',
+      })
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+      }
+    agentState.canSuggestFollowups = true
+    const followupAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-followup-agent',
+      toolNames: ['code_search', 'suggest_followups', 'end_turn'],
+    }
+
+    await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-followup-agent',
+      localAgentTemplates: { 'test-followup-agent': followupAgent },
+      agentTemplate: followupAgent,
+      agentState,
+      prompt: 'Suggest followups and then try to search',
+    })
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'suggest_followups',
+      }),
+    )
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
+        ),
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({ type: 'tool_call', toolName: 'code_search' }),
+    )
+  })
+
+  it('blocks non-terminal tools across batches after suggest_followups is emitted', async () => {
+    // Regression: toolCalls accumulates within a step, but the emitted flag is
+    // the safety net so a later batch cannot run spawn/search after followups.
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+    }
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      yield createToolCallChunk('suggest_followups', {
+        followups: [{ prompt: 'Add tests', label: 'Add tests' }],
+      })
+      // Force a second tool-call batch after suggest_followups has executed.
+      yield createToolCallChunk('spawn_agents', {
+        agents: [{ agent_type: 'code-searcher', prompt: 'Search more' }],
+      })
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState(mockFileContext)
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+        suggestFollowupsEmitted?: boolean
+      }
+    agentState.canSuggestFollowups = true
+    const followupAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-followup-agent',
+      toolNames: ['spawn_agents', 'suggest_followups', 'end_turn'],
+      spawnableAgents: ['code-searcher'],
+    }
+
+    await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-followup-agent',
+      localAgentTemplates: { 'test-followup-agent': followupAgent },
+      agentTemplate: followupAgent,
+      agentState,
+      prompt: 'Suggest followups then spawn more work',
+    })
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'suggest_followups',
+      }),
+    )
+    expect(agentState.suggestFollowupsEmitted).toBe(true)
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
+        ),
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({ type: 'tool_call', toolName: 'spawn_agents' }),
+    )
+  })
+
+  it('blocks custom/MCP tools after same-step suggest_followups while end_turn still succeeds', async () => {
+    // Regression RF-2: executeCustomToolCall must share the post-followups
+    // last-tool helper so a custom/MCP tool after same-step suggest_followups
+    // is rejected while terminal companions still run.
+    const customToolName = 'custom_search'
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+      fileContext: {
+        ...mockFileContext,
+        customToolDefinitions: {
+          [customToolName]: {
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+              required: ['query'],
+              additionalProperties: false,
+            },
+            endsAgentStep: false,
+            description: 'Custom tool for post-followups regression',
+          },
+        },
+      },
+      requestToolCall: async () => ({
+        output: [
+          {
+            type: 'json',
+            value: { ok: true },
+          },
+        ],
+      }),
+    }
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      yield createToolCallChunk('suggest_followups', {
+        followups: [{ prompt: 'Add tests', label: 'Add tests' }],
+      })
+      yield createToolCallChunk(customToolName, {
+        query: 'after followups',
+      })
+      yield createToolCallChunk('end_turn', {})
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState({
+      ...mockFileContext,
+      customToolDefinitions: {
+        [customToolName]: {
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+            },
+            required: ['query'],
+            additionalProperties: false,
+          },
+          endsAgentStep: false,
+          description: 'Custom tool for post-followups regression',
+        },
+      },
+    })
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+      }
+    agentState.canSuggestFollowups = true
+    const followupAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-followup-agent',
+      toolNames: [customToolName, 'suggest_followups', 'end_turn'],
+    }
+
+    const result = await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-followup-agent',
+      localAgentTemplates: { 'test-followup-agent': followupAgent },
+      agentTemplate: followupAgent,
+      agentState,
+      prompt: 'Suggest followups then call a custom tool',
+    })
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'suggest_followups',
+      }),
+    )
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
+        ),
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: customToolName,
+      }),
+    )
+    expect(chunks).toContainEqual(
+      expect.objectContaining({ type: 'tool_call', toolName: 'end_turn' }),
+    )
+    expect(result.shouldEndTurn).toBe(true)
+  })
+
+  it('blocks custom/MCP tools after same-step suggest_followups while task_completed still succeeds', async () => {
+    // Companion to the end_turn custom/MCP case: executeCustomToolCall must
+    // still reject a custom/MCP tool after same-step suggest_followups while
+    // the task_completed terminal companion still runs.
+    const customToolName = 'custom_search'
+    const chunks: unknown[] = []
+    runAgentStepBaseParams = {
+      ...runAgentStepBaseParams,
+      onResponseChunk: (chunk) => chunks.push(chunk),
+      fileContext: {
+        ...mockFileContext,
+        customToolDefinitions: {
+          [customToolName]: {
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+              required: ['query'],
+              additionalProperties: false,
+            },
+            endsAgentStep: false,
+            description: 'Custom tool for post-followups regression',
+          },
+        },
+      },
+      requestToolCall: async () => ({
+        output: [
+          {
+            type: 'json',
+            value: { ok: true },
+          },
+        ],
+      }),
+    }
+    runAgentStepBaseParams.promptAiSdkStream = async function* ({}) {
+      yield createToolCallChunk('suggest_followups', {
+        followups: [{ prompt: 'Add tests', label: 'Add tests' }],
+      })
+      yield createToolCallChunk(customToolName, {
+        query: 'after followups',
+      })
+      yield createToolCallChunk('task_completed', {})
+      return promptSuccess('mock-message-id')
+    }
+
+    const sessionState = getInitialSessionState({
+      ...mockFileContext,
+      customToolDefinitions: {
+        [customToolName]: {
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+            },
+            required: ['query'],
+            additionalProperties: false,
+          },
+          endsAgentStep: false,
+          description: 'Custom tool for post-followups regression',
+        },
+      },
+    })
+    const agentState =
+      sessionState.mainAgentState as typeof sessionState.mainAgentState & {
+        canSuggestFollowups?: boolean
+      }
+    agentState.canSuggestFollowups = true
+    const followupAgent: AgentTemplate = {
+      ...testAgent,
+      id: 'test-followup-agent',
+      toolNames: [customToolName, 'suggest_followups', 'task_completed'],
+    }
+
+    const result = await runAgentStep({
+      ...runAgentStepBaseParams,
+      agentType: 'test-followup-agent',
+      localAgentTemplates: { 'test-followup-agent': followupAgent },
+      agentTemplate: followupAgent,
+      agentState,
+      prompt: 'Suggest followups then call a custom tool',
+    })
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'suggest_followups',
+      }),
+    )
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(
+          /No tools are available after suggest_followups|suggest_followups already ended the actionable work/,
+        ),
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: customToolName,
+      }),
+    )
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool_call',
+        toolName: 'task_completed',
+      }),
+    )
+    expect(result.shouldEndTurn).toBe(true)
   })
 
   it('should handle handleSteps with one tool call and STEP_ALL', async () => {

--- a/packages/agent-runtime/src/tools/tool-executor.ts
+++ b/packages/agent-runtime/src/tools/tool-executor.ts
@@ -1470,6 +1470,52 @@ function isFileChangingTool(toolName: string): boolean {
   )
 }
 
+const POST_FOLLOWUPS_ERROR_MESSAGE =
+  'No tools are available after suggest_followups in the same step (except end_turn/task_completed). suggest_followups must be the absolute last actionable tool after the completion summary (and after git-committer if committing).'
+const ALREADY_EMITTED_FOLLOWUPS_ERROR_MESSAGE =
+  'suggest_followups already ended the actionable work for this turn. No more non-terminal tools are available after followups (except end_turn/task_completed).'
+
+function isTerminalFollowupCompanion(name: string): boolean {
+  return (
+    name === 'suggest_followups' ||
+    name === 'end_turn' ||
+    name === 'task_completed'
+  )
+}
+
+function getPostSuggestFollowupsBlockReason(params: {
+  // Accept AgentState and read the extra runtime flags via the same cast
+  // pattern used by executeToolCall; these fields are intentionally not on
+  // the public AgentState type.
+  agentState: AgentState
+  toolName: string
+  toolCalls: { toolName: string }[]
+}): string | null {
+  const followupFlags = params.agentState as AgentState & {
+    canSuggestFollowups?: boolean
+    suggestFollowupsEmitted?: boolean
+  }
+  const canSuggestFollowups = followupFlags.canSuggestFollowups
+  const suggestFollowupsEmitted = followupFlags.suggestFollowupsEmitted === true
+  // Gate system is active for base2-style agents that publish canSuggestFollowups
+  // (true or false). Non-base2/custom agents leave it undefined and keep prior
+  // followups behavior unchanged unless they already set the emitted flag.
+  const gateSystemActive = canSuggestFollowups !== undefined
+  if (!(gateSystemActive || suggestFollowupsEmitted)) {
+    return null
+  }
+  if (isTerminalFollowupCompanion(params.toolName)) {
+    return null
+  }
+  if (suggestFollowupsEmitted) {
+    return ALREADY_EMITTED_FOLLOWUPS_ERROR_MESSAGE
+  }
+  if (params.toolCalls.some((call) => call.toolName === 'suggest_followups')) {
+    return POST_FOLLOWUPS_ERROR_MESSAGE
+  }
+  return null
+}
+
 export function sanitizePathSegment(segment: string): string {
   // Strip path separators (forward/back slash, null byte) and parent-directory
   // traversal (..) so an agent-supplied identifier (e.g. write_audit_findings
@@ -1977,6 +2023,29 @@ export async function executeToolCall<T extends ToolName>(
 
   const canSuggestFollowups = (agentState as { canSuggestFollowups?: boolean })
     .canSuggestFollowups
+  // Gate system is active for base2-style agents that publish canSuggestFollowups
+  // (true or false). Non-base2/custom agents leave it undefined and keep prior
+  // followups behavior unchanged unless they already set the emitted flag.
+  const gateSystemActive = canSuggestFollowups !== undefined
+
+  // Last-tool enforcement: once followups have been emitted (or already appear
+  // earlier in this step's toolCalls), only terminal companions may run. This
+  // broadens the old file-edit-only block so spawn/search/validation cannot
+  // continue after followups mid-turn. Shared with executeCustomToolCall so
+  // custom/MCP tools cannot skip the same-step last-tool + emitted-flag check.
+  const postFollowupsBlockReason = getPostSuggestFollowupsBlockReason({
+    agentState,
+    toolName,
+    toolCalls,
+  })
+  if (postFollowupsBlockReason) {
+    onResponseChunk({
+      type: 'error',
+      message: postFollowupsBlockReason,
+    })
+    return abortablePreviousToolCallFinished
+  }
+
   if (toolName === 'suggest_followups') {
     if (
       canSuggestFollowups === false ||
@@ -1989,17 +2058,13 @@ export async function executeToolCall<T extends ToolName>(
       })
       return abortablePreviousToolCallFinished
     }
-  } else if (
-    canSuggestFollowups === true &&
-    isFileChangingTool(toolName) &&
-    toolCalls.some((call) => call.toolName === 'suggest_followups')
-  ) {
-    onResponseChunk({
-      type: 'error',
-      message:
-        'File-changing tools are not available after suggest_followups in the same step. If more edits are needed, make them before final follow-up suggestions so validation and review can rerun.',
-    })
-    return abortablePreviousToolCallFinished
+    // Mark followups as emitted only on the allow path (not early returns) so
+    // later tool-call batches in the same step cannot run non-terminal work.
+    // Only set when the gate system is active so custom agents stay free.
+    if (gateSystemActive) {
+      ;(agentState as { suggestFollowupsEmitted?: boolean })
+        .suggestFollowupsEmitted = true
+    }
   }
 
   // Retract suggest_followups permission for the remainder of this step as
@@ -2878,6 +2943,21 @@ export async function executeCustomToolCall(
     previousToolCallFinished,
     params.signal,
   )
+  // Same last-tool / emitted-flag enforcement as executeToolCall. Custom and
+  // MCP tools are never terminal companions, so they must not run after
+  // same-step suggest_followups (or after the emitted flag is already set).
+  const postFollowupsBlockReason = getPostSuggestFollowupsBlockReason({
+    agentState,
+    toolName,
+    toolCalls,
+  })
+  if (postFollowupsBlockReason) {
+    onResponseChunk({
+      type: 'error',
+      message: postFollowupsBlockReason,
+    })
+    return abortablePreviousToolCallFinished
+  }
   const toolCall: CustomToolCall | ToolCallError = parseRawCustomToolCall({
     customToolDefs: await getMCPToolData({
       ...params,


### PR DESCRIPTION
## Summary
Force test-writer and doc-writer onto edit_transaction only (drop standalone str_replace/write_file). Update prompts, guide, public docs (with payload example), and contract tests.

## Audit
- git-committer: no standalone file edits
- general-agent: findings-only writes
- dependency-manager: programmatic write_file/apply_patch for rollback only (intentional)

## Test plan
- [x] bun test agents/__tests__/new-bundled-agents.test.ts agents/tool-reachability.test.ts (71 passed)
- [x] agents typecheck / hooks on writer files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/57)
<!-- Reviewable:end -->
