### PR TITLE
Relax workspace-write terminal policy for monorepo agents

### DIFF
--- a/scripts/harness-smoke.mjs
+++ b/scripts/harness-smoke.mjs
@@ -98,6 +98,26 @@ expectPolicy(
 )
 
 expectPolicy(
+  'policy: git restore --staged -- under git-commit allowlist',
+  {
+    command: 'git restore --staged -- src/a.ts',
+    permissionProfile: 'git-commit',
+    allowedPaths: ['src/a.ts'],
+  },
+  (decision) => decision.allowed === true,
+)
+
+expectPolicy(
+  'policy: git restore --staged other.ts denied by allowlist',
+  {
+    command: 'git restore --staged other.ts',
+    permissionProfile: 'git-commit',
+    allowedPaths: ['src/a.ts'],
+  },
+  (decision) => decision.allowed === false,
+)
+
+expectPolicy(
   'policy: bare git restore under git-commit denied',
   {
     command: 'git restore src/a.ts',
@@ -115,14 +135,44 @@ expectPolicy(
     command: basherPipe,
     permissionProfile: 'workspace-write',
   },
-  (decision) => {
-    // Allowed, or at least not denied solely as a high-impact harness action.
-    if (decision.allowed) return true
-    const reason = 'reason' in decision ? decision.reason : ''
-    const highImpactDenial =
-      /high-impact|arbitrary-code|workspace-delete|approval/i.test(reason)
-    return !highImpactDenial
+  (decision) => decision.allowed === true,
+)
+
+expectPolicy(
+  'policy: workspace-write echo $(date) allowed',
+  {
+    command: 'echo $(date)',
+    permissionProfile: 'workspace-write',
   },
+  (decision) => decision.allowed === true,
+)
+
+expectPolicy(
+  'policy: workspace-write echo $(printenv) denied',
+  {
+    command: 'echo $(printenv)',
+    permissionProfile: 'workspace-write',
+  },
+  (decision) => decision.allowed === false,
+)
+
+expectPolicy(
+  'policy: workspace-write gh pr create allowed',
+  {
+    command: 'gh pr create --title test --body ok',
+    permissionProfile: 'workspace-write',
+  },
+  (decision) => decision.allowed === true,
+)
+
+expectPolicy(
+  'policy: workspace-write cd .. from package cwd allowed',
+  {
+    command: 'cd .. && bun test',
+    permissionProfile: 'workspace-write',
+    cwd: path.join(projectRoot, 'packages', 'sdk'),
+  },
+  (decision) => decision.allowed === true,
 )
 
 if (failures > 0) {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -114,8 +114,12 @@ Inputs:
   (direct user input is not gated here).
 - `permissionProfile` — one of the profiles below.
 - `projectRoot` — the workspace root used for path-containment checks.
+- `cwd` — optional in-project working directory. When provided, relative
+  `..` tokens under `workspace-write` and `validation-diagnosis` resolve
+  against this directory instead of `projectRoot`. The resolved path must
+  still stay inside `projectRoot`; `cd ..` from the repo root stays denied.
 - `allowedPaths` — optional owned-path allowlist, required for `git add`
-  staging under `git-commit`.
+  and `git restore --staged` under `git-commit`.
 
 Profiles:
 
@@ -131,8 +135,9 @@ Profiles:
   expansion-free paths that resolve inside the project.
 - `git-commit` — inspect/fetch Git state, stage explicit owned paths, create a
   non-`--amend` commit with `-m`/`--message`, and perform an explicit
-  non-force branch push. `git add` paths must be an exact subset of
-  `allowedPaths`; broad flags, dot staging, options, and globs are forbidden.
+  non-force branch push. `git add` and `git restore --staged` paths must be
+  an exact subset of `allowedPaths`; broad flags, dot staging, options, and
+  globs are forbidden.
   Whole-subject placeholder commit messages such as bare `probe`, `wip`,
   `test`, `tmp`, `update`, or `misc` are denied; real imperative subjects that
   merely contain those words stay allowed. Safe single-command branch/switch,
@@ -154,8 +159,15 @@ Profiles:
   Git commands are denied. Fixture creation is not authorized through the
   shell; use a dedicated terminal executor with private fixture creation.
   Outside-absolute-path containment and env-dump denial still apply.
-- `workspace-write` — general workspace writes; in-project `..` references are
-  allowed, escaping segments are rejected.
+- `workspace-write` — general workspace writes. Everyday bash (`for`/`if`/
+  `while`/`case`, pipelines, and normal control flow) is allowed. In-project
+  `..` references are allowed, including `cd ..` from a contained `cwd` that
+  still lands inside the project; escaping segments are rejected. Command and
+  process substitution (`$(...)`, backticks, `<(...)`) are inspected for env
+  dumps rather than denied wholesale, so `echo $(date)` is allowed while
+  `echo $(printenv)` is not. `gh pr create` and other GitHub PR mutation verbs
+  are allowed here (they remain denied on `read-only` and stay routine in
+  balanced harness approval).
 - `full-access` — bypasses the policy gates. Use only through an explicit
   full-access workflow.
 
@@ -173,7 +185,13 @@ substitution forms such as `command printenv`, `env printenv`, `nice env`, or
 `cat <(printenv)`; option-only `set -euo pipefail` and workspace-style
 `export NAME[=value]` / `env NAME=value <utility>` remain allowed where the
 profile permits) are denied for every non-`full-access` profile, including
-`tmux-test`. Under `read-only` / `librarian-read-only` / `validation-diagnosis`,
+`tmux-test`. Under `workspace-write` only, active `$()` / backticks /
+process substitution are not treated as dumps unless a substitution body or
+remaining segment actually dumps the environment; unextractable substitutions
+do not fail closed as env-dump. `read-only`, `librarian-read-only`,
+`validation-diagnosis`, `tmux-test`, `git-commit`, and `dependency-mutation`
+still fail closed on substitution and unparseable composition for env-dump.
+Under `read-only` / `librarian-read-only` / `validation-diagnosis`,
 env mutation forms such as `export NAME=value` and `env NAME=value cmd` are
 also denied. The `tmux-test` profile still skips the other workspace deny
 patterns because it is governed by its own stricter no-shell-write guard
@@ -192,10 +210,10 @@ that blocked it.
     (those are classified as `arbitrary-code` and need approval in balanced
     mode).
   - Do not embed multi-KB heredocs or live `$()` that dump env in the basher
-    `params.command` string — env dumps (`env`/`printenv`/bare `set`) and some
-    substitution forms are still denied by terminal policy even when not
-    high-impact harness actions. Author files with edit tools; run short
-    commands.
+    `params.command` string — env dumps (`env`/`printenv`/bare `set`) stay
+    denied even when ordinary `$(date)` / `$(pwd)` substitutions and `gh pr`
+    are allowed under `workspace-write` and are not high-impact harness
+    actions. Author files with edit tools; run short commands.
   - Durable local check (from monorepo root): `bun run check:ci-local` (the early-gates bundle: tool defs + memory-drift + sync-agent-config).
 
 ## Search tool working directory

--- a/sdk/src/__tests__/harness-enforcement.test.ts
+++ b/sdk/src/__tests__/harness-enforcement.test.ts
@@ -126,6 +126,13 @@ describe('harness enforcement services', () => {
         hasMatchingApproval: false,
       }),
     ).toMatchObject({ allowed: false, approvalRequired: true })
+    expect(
+      evaluateHarnessActionPolicy({
+        action: 'pull-request',
+        target: 'gh pr create --title test',
+        hasMatchingApproval: false,
+      }),
+    ).toEqual({ allowed: true, approvalRequired: false })
   })
 
   test('classifies only recognized high-impact command shapes', () => {
@@ -235,6 +242,12 @@ describe('harness enforcement services', () => {
     expect(
       classifyTerminalHarnessAction('echo "$(git rev-parse --short HEAD)"'),
     ).toBeUndefined()
+    expect(
+      classifyTerminalHarnessAction('gh pr create --title test'),
+    ).toEqual({
+      action: 'pull-request',
+      target: 'gh pr create --title test',
+    })
     expect(classifyTerminalHarnessAction('bun test')).toBeUndefined()
     expect(classifyTerminalHarnessAction('nohup bun test')).toMatchObject({
       action: 'arbitrary-code',

--- a/sdk/src/__tests__/terminal-command-policy.test.ts
+++ b/sdk/src/__tests__/terminal-command-policy.test.ts
@@ -320,6 +320,104 @@ describe('terminal command permission policy', () => {
     ).toBe(false)
   })
 
+  it('resolves relative traversal against cwd under workspace-write', () => {
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'cd packages/sdk && bun test',
+        mode: 'assistant',
+        permissionProfile: 'workspace-write',
+        projectRoot,
+      }),
+    ).toEqual({ allowed: true })
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'cd .. && bun test',
+        mode: 'assistant',
+        permissionProfile: 'workspace-write',
+        projectRoot,
+        cwd: '/workspace/project/packages/sdk',
+      }),
+    ).toEqual({ allowed: true })
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'cd ..',
+        mode: 'assistant',
+        permissionProfile: 'workspace-write',
+        projectRoot,
+      }).allowed,
+    ).toBe(false)
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'cd ..',
+        mode: 'assistant',
+        permissionProfile: 'workspace-write',
+        projectRoot,
+        cwd: projectRoot,
+      }).allowed,
+    ).toBe(false)
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'cd ../../../etc',
+        mode: 'assistant',
+        permissionProfile: 'workspace-write',
+        projectRoot,
+        cwd: '/workspace/project/packages/sdk',
+      }).allowed,
+    ).toBe(false)
+  })
+
+  it('allows everyday workspace-write bash, non-dump substitutions, and gh pr', () => {
+    for (const command of [
+      'for f in src/*; do echo "$f"; done',
+      'if true; then git status --short; fi',
+      'while false; do echo x; done',
+      'case $x in a) echo a;; esac',
+      'echo $(date)',
+      'echo $(pwd)',
+      'git log --oneline $(git rev-parse HEAD)',
+      'gh pr create --title test --body ok',
+    ]) {
+      expect(
+        evaluateTerminalCommandPolicy({
+          command,
+          mode: 'assistant',
+          permissionProfile: 'workspace-write',
+          projectRoot,
+        }),
+      ).toEqual({ allowed: true })
+    }
+    for (const command of [
+      'echo $(printenv)',
+      'echo "$(printenv)"',
+      'cat <(printenv)',
+      'echo $(echo $(printenv))',
+      'echo $(head | printenv)',
+    ]) {
+      expect(
+        evaluateTerminalCommandPolicy({
+          command,
+          mode: 'assistant',
+          permissionProfile: 'workspace-write',
+          projectRoot,
+        }).allowed,
+      ).toBe(false)
+    }
+    for (const command of [
+      'gh pr create --title test',
+      'echo $(printenv)',
+      'rg TODO packages/../src',
+    ]) {
+      expect(
+        evaluateTerminalCommandPolicy({
+          command,
+          mode: 'assistant',
+          permissionProfile: 'read-only',
+          projectRoot,
+        }).allowed,
+      ).toBe(false)
+    }
+  })
+
   it('allows the word source inside quoted arguments but blocks real shell indirection in workspace-write', () => {
     // "source" appearing only inside a quoted argument is not indirection.
     expect(
@@ -673,6 +771,27 @@ describe('terminal command permission policy', () => {
     }
   })
 
+  it('applies the git-commit allowedPaths allowlist to staged restore', () => {
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'git restore --staged -- src/a.ts',
+        mode: 'assistant',
+        permissionProfile: 'git-commit',
+        projectRoot,
+        allowedPaths: ['src/a.ts'],
+      }).allowed,
+    ).toBe(true)
+    expect(
+      evaluateTerminalCommandPolicy({
+        command: 'git restore --staged other.ts',
+        mode: 'assistant',
+        permissionProfile: 'git-commit',
+        projectRoot,
+        allowedPaths: ['src/a.ts'],
+      }).allowed,
+    ).toBe(false)
+  })
+
   it('allows safe complex git operations for git-commit agents', () => {
     for (const command of [
       'git switch feature/x',
@@ -693,6 +812,7 @@ describe('terminal command permission policy', () => {
       'git tag v1.0.0',
       'git tag -a v1.0.0 -m rel',
       'git restore --staged src/a.ts',
+      'git restore --staged -- src/a.ts',
     ]) {
       expect(
         evaluateTerminalCommandPolicy({

--- a/sdk/src/tools/run-terminal-command.ts
+++ b/sdk/src/tools/run-terminal-command.ts
@@ -266,13 +266,13 @@ export function runTerminalCommand({
   )
   // The helper also honors the openbuff-owned OS temp namespace exception,
   // which exists so path-taking tools can READ openbuff's own artifacts — not
-  // so a child process can be hosted there. `evaluateTerminalCommandPolicy`
-  // below still resolves relative command tokens against `projectRoot`, so an
-  // owned-temp cwd would let a policy-clean relative token land in a
-  // world-writable directory. Require an in-project result: the resolver's
-  // `scope` discriminator marks that exception explicitly, so an owned-temp
-  // path is refused without also rejecting a project root that legitimately
-  // lives under the temp dir.
+  // so a child process can be hosted there. Policy evaluation receives the
+  // in-project `containedCwd` so relative `..` tokens resolve from the real
+  // working directory; an owned-temp cwd would still let a policy-clean
+  // relative token land in a world-writable directory. Require an in-project
+  // result: the resolver's `scope` discriminator marks that exception
+  // explicitly, so an owned-temp path is refused without also rejecting a
+  // project root that legitimately lives under the temp dir.
   if (resolvedCwd === null || resolvedCwd.scope === 'owned-temp') {
     return Promise.resolve([
       {
@@ -292,6 +292,7 @@ export function runTerminalCommand({
     permissionProfile: permission_profile,
     projectRoot: projectRoot ?? process.cwd(),
     allowedPaths: allowed_paths,
+    cwd: containedCwd,
   })
   if (!policy.allowed) {
     return Promise.resolve([

--- a/sdk/src/tools/terminal-command-policy.ts
+++ b/sdk/src/tools/terminal-command-policy.ts
@@ -431,12 +431,210 @@ function findProcessEnvironmentIssue(
 }
 
 
+/**
+ * Extract active `$(...)` / backtick / `<(...)` / `>(...)` bodies and the
+ * remainder with those spans replaced by spaces. Single-quoted openers are
+ * inert; double-quoted `$(` / backticks stay active. Nested parens are
+ * quote-aware. Returns undefined when an opener has no matching closer.
+ */
+function extractSubstitutionsAndRemainder(
+  command: string,
+): { bodies: string[]; remainder: string } | undefined {
+  const bodies: string[] = []
+  let remainder = ''
+  let quote: "'" | '"' | null = null
+  let escaped = false
+
+  const takeParenBody = (
+    openParenIndex: number,
+  ): { body: string; endIndex: number } | undefined => {
+    let depth = 1
+    let innerQuote: "'" | '"' | null = null
+    let innerEscaped = false
+    for (let index = openParenIndex + 1; index < command.length; index += 1) {
+      const char = command[index]
+      if (innerEscaped) {
+        innerEscaped = false
+        continue
+      }
+      if (char === '\\' && innerQuote !== "'") {
+        innerEscaped = true
+        continue
+      }
+      if (innerQuote) {
+        if (char === innerQuote) innerQuote = null
+        continue
+      }
+      if (char === "'" || char === '"') {
+        innerQuote = char
+        continue
+      }
+      if (char === '(') depth += 1
+      else if (char === ')') {
+        depth -= 1
+        if (depth === 0) {
+          return {
+            body: command.slice(openParenIndex + 1, index),
+            endIndex: index,
+          }
+        }
+      }
+    }
+    return undefined
+  }
+
+  const takeBacktickBody = (
+    openIndex: number,
+  ): { body: string; endIndex: number } | undefined => {
+    let innerEscaped = false
+    for (let index = openIndex + 1; index < command.length; index += 1) {
+      const char = command[index]
+      if (innerEscaped) {
+        innerEscaped = false
+        continue
+      }
+      if (char === '\\') {
+        innerEscaped = true
+        continue
+      }
+      if (char === '`') {
+        return {
+          body: command.slice(openIndex + 1, index),
+          endIndex: index,
+        }
+      }
+    }
+    return undefined
+  }
+
+  const takeSubstitution = (
+    index: number,
+    kind: 'command' | 'backtick' | 'process',
+  ): { body: string; endIndex: number } | undefined => {
+    if (kind === 'backtick') return takeBacktickBody(index)
+    return takeParenBody(index + 1)
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]
+    if (escaped) {
+      escaped = false
+      remainder += char
+      continue
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true
+      remainder += char
+      continue
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null
+        remainder += char
+        continue
+      }
+      if (
+        quote === '"' &&
+        (char === '`' || (char === '$' && command[index + 1] === '('))
+      ) {
+        const extracted = takeSubstitution(
+          index,
+          char === '`' ? 'backtick' : 'command',
+        )
+        if (!extracted) return undefined
+        bodies.push(extracted.body)
+        remainder += ' '
+        index = extracted.endIndex
+        continue
+      }
+      remainder += char
+      continue
+    }
+    if (char === "'" || char === '"') {
+      quote = char
+      remainder += char
+      continue
+    }
+    if (char === '`' || (char === '$' && command[index + 1] === '(')) {
+      const extracted = takeSubstitution(
+        index,
+        char === '`' ? 'backtick' : 'command',
+      )
+      if (!extracted) return undefined
+      bodies.push(extracted.body)
+      remainder += ' '
+      index = extracted.endIndex
+      continue
+    }
+    if ((char === '<' || char === '>') && command[index + 1] === '(') {
+      const extracted = takeSubstitution(index, 'process')
+      if (!extracted) return undefined
+      bodies.push(extracted.body)
+      remainder += ' '
+      index = extracted.endIndex
+      continue
+    }
+    remainder += char
+  }
+  return { bodies, remainder }
+}
+
+/** Recursively collect remainder + substitution bodies for env-dump scans. */
+function collectEnvDumpScanPieces(command: string): string[] | undefined {
+  const extracted = extractSubstitutionsAndRemainder(command)
+  if (!extracted) return undefined
+  const pieces = [extracted.remainder]
+  for (const body of extracted.bodies) {
+    const nested = collectEnvDumpScanPieces(body)
+    if (nested === undefined) {
+      pieces.push(body)
+    } else {
+      pieces.push(...nested)
+    }
+  }
+  return pieces
+}
+
+function findProcessEnvironmentIssueInPieces(
+  pieces: string[],
+  style: 'workspace' | 'read-only',
+): string | undefined {
+  for (const piece of pieces) {
+    const trimmed = piece.trim()
+    if (!trimmed) continue
+    const segments = splitReadOnlyShellSegments(trimmed)
+    if (!segments) {
+      const issue = findProcessEnvironmentIssue(trimmed, style)
+      if (issue) return issue
+      continue
+    }
+    for (const segment of segments) {
+      const issue = findProcessEnvironmentIssue(segment, style)
+      if (issue) return issue
+    }
+  }
+  return undefined
+}
+
 function findProcessEnvironmentIssueInCommand(
   command: string,
   style: 'workspace' | 'read-only',
+  substitutionMode: 'fail-closed' | 'inspect-bodies' = 'fail-closed',
 ): string | undefined {
   const reason =
     style === 'workspace' ? WORKSPACE_ENV_DUMP_REASON : READ_ONLY_ENV_DUMP_REASON
+  if (substitutionMode === 'inspect-bodies') {
+    // Workspace-write: inspect substitution bodies and remaining segments
+    // instead of treating every `$()` / process substitution as a dump.
+    // Unextractable substitutions do not fail closed as env-dump.
+    const pieces = collectEnvDumpScanPieces(command)
+    if (!pieces) {
+      const segments = splitReadOnlyShellSegments(command)
+      if (!segments) return undefined
+      return findProcessEnvironmentIssueInPieces(segments, style)
+    }
+    return findProcessEnvironmentIssueInPieces(pieces, style)
+  }
   // Double-quoted `$(…)`/backticks stay active and can hide dumps, but
   // splitReadOnlyShellSegments only fails closed on unquoted substitution.
   // Process substitution `<(…)` / `>(…)` similarly conceals dump utilities.
@@ -451,11 +649,7 @@ function findProcessEnvironmentIssueInCommand(
   if (!segments) {
     return reason
   }
-  for (const segment of segments) {
-    const issue = findProcessEnvironmentIssue(segment, style)
-    if (issue) return issue
-  }
-  return undefined
+  return findProcessEnvironmentIssueInPieces(segments, style)
 }
 
 const DEPENDENCY_MUTATION_COMMANDS = [
@@ -1021,27 +1215,41 @@ function hasUnsafeTmuxFileMutation(command: string): boolean {
 }
 
 /**
- * Traversal guard for the validation-diagnosis profile: rejects only `..`
- * tokens whose path resolves outside the project root, so diagnostic repros
- * may reference in-project siblings such as `../src/languages` from a package
- * subdirectory. Absolute tokens are resolved directly; relative tokens are
- * resolved against the project root, which is conservative for in-project
- * working directories (a false rejection is possible for `../..` from a
- * deeply nested cwd that still lands inside the root). Absolute paths that
+ * Traversal guard for validation-diagnosis and workspace-write: rejects only
+ * `..` tokens whose path resolves outside the project root, so in-project
+ * siblings such as `../src/languages` or `cd ..` from a package subdirectory
+ * stay allowed. Absolute tokens are resolved directly. Relative tokens resolve
+ * against `cwd` when it is provided and itself contained in the project;
+ * otherwise they resolve against the project root (the previous conservative
+ * behavior). A `cwd` outside the project fail-closes relative `..` tokens.
+ * The final resolved path must stay inside projectRoot. Absolute paths that
  * escape the project are also rejected by findOutsideAbsolutePath.
  */
 function findEscapingTraversalPath(
   command: string,
   projectRoot: string,
+  cwd?: string,
 ): string | undefined {
   const root = path.resolve(projectRoot)
+  let resolveBase = root
+  let cwdOutsideProject = false
+  if (cwd !== undefined) {
+    const resolvedCwd = path.resolve(cwd)
+    const relativeCwd = path.relative(root, resolvedCwd)
+    if (relativeCwd.startsWith('..') || path.isAbsolute(relativeCwd)) {
+      cwdOutsideProject = true
+    } else {
+      resolveBase = resolvedCwd
+    }
+  }
   const tokens = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []
   for (const rawToken of tokens) {
     const token = rawToken.replace(/^["']|["',);]+$/g, '')
     if (!token.split(/[=\\/]+/).includes('..')) continue
+    if (!path.isAbsolute(token) && cwdOutsideProject) return rawToken
     const resolved = path.isAbsolute(token)
       ? path.resolve(token)
-      : path.resolve(root, token)
+      : path.resolve(resolveBase, token)
     const relative = path.relative(root, resolved)
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       return rawToken
@@ -1372,7 +1580,14 @@ function isAllowedComplexGitCommand(command: string): boolean {
   // Data-loss / history-rewrite guards - reject before the allow disjunction so
   // a too-loose pattern can never re-admit a destructive shape.
   if (/\s--hard\b/i.test(command)) return false // reset --hard destroys work
-  if (/\s--(?:\s|$)/.test(command)) return false // pathspec `--` (path checkout/reset overwrite)
+  // pathspec `--` overwrites the worktree for checkout/reset. Staged-only
+  // restore uses `--` as a harmless pathspec separator and is exempted.
+  if (
+    /\s--(?:\s|$)/.test(command) &&
+    !/^git\s+restore\s+--staged\b/i.test(command)
+  ) {
+    return false
+  }
   // restore worktree/patch/source/overlay overwrite (data loss): deny any
   // restore carrying --worktree/-W, --patch/-p, --source, or --overlay.
   if (/\brestore\b[\s\S]*(?:--worktree\b|-[A-Za-z]*W\b|--patch\b|-[A-Za-z]*p\b|--source\b|--overlay\b)/i.test(command)) return false
@@ -1437,10 +1652,13 @@ function isAllowedComplexGitCommand(command: string): boolean {
       /^git\s+tag\s+(?:-[aA]\s+)?(?:-m\s+\S+\s+)*[A-Za-z0-9._/][A-Za-z0-9._/-]*(?:\s+-m\s+\S+)?(?:\s+[A-Za-z0-9._/][A-Za-z0-9._/-]*)?\s*$/i.test(
         commandForAllow,
       )) ||
-    // restore --staged only: every path token must start with a non-dash
-    // (negative lookahead) so --worktree/-W/--patch/-p/--source/--overlay cannot
-    // be smuggled as a path; those shapes are also denied by the guard above.
-    /^git\s+restore\s+--staged(?:\s+(?!-)[A-Za-z0-9._/-]+)+\s*$/i.test(commandForAllow)
+    // restore --staged only: optional pathspec `--`, then every path token
+    // must start with a non-dash (negative lookahead) so --worktree/-W/
+    // --patch/-p/--source/--overlay cannot be smuggled as a path; those
+    // shapes are also denied by the guard above.
+    /^git\s+restore\s+--staged(?:\s+--)?(?:\s+(?!-)[A-Za-z0-9._/-]+)+\s*$/i.test(
+      commandForAllow,
+    )
   )
 }
 
@@ -1507,6 +1725,7 @@ export function evaluateTerminalCommandPolicy(params: {
   permissionProfile: TerminalPermissionProfile
   projectRoot: string
   allowedPaths?: string[]
+  cwd?: string
 }): TerminalPolicyDecision {
   if (params.mode === 'user') return { allowed: true }
   const heredocCommand =
@@ -1530,14 +1749,16 @@ export function evaluateTerminalCommandPolicy(params: {
   if (params.permissionProfile !== 'full-access') {
     // validation-diagnosis (the debugger profile) and workspace-write may
     // reference paths with `..` segments that still resolve inside the project
-    // (e.g. a repro pointing at `../src/languages` from a package subdirectory).
-    // They still reject segments that escape the project root, and absolute
-    // paths outside the project stay blocked by findOutsideAbsolutePath below.
-    // Base read-only and librarian-read-only keep the blanket `..` ban.
+    // (e.g. a repro pointing at `../src/languages` from a package subdirectory,
+    // or `cd ..` from an in-project cwd). Relative `..` tokens resolve against
+    // params.cwd when provided. They still reject segments that escape the
+    // project root, and absolute paths outside the project stay blocked by
+    // findOutsideAbsolutePath below. Base read-only and librarian-read-only
+    // keep the blanket `..` ban.
     const traversalPath =
       params.permissionProfile === 'validation-diagnosis' ||
       params.permissionProfile === 'workspace-write'
-        ? findEscapingTraversalPath(command, params.projectRoot)
+        ? findEscapingTraversalPath(command, params.projectRoot, params.cwd)
         : findTraversalPath(command)
     if (traversalPath) {
       return {
@@ -1612,10 +1833,16 @@ export function evaluateTerminalCommandPolicy(params: {
       }
     } else {
       const isGitAdd = /^git\s+add\b/i.test(command)
-      if (isGitAdd) {
+      const isGitRestoreStaged = /^git\s+restore\s+--staged\b/i.test(command)
+      if (isGitAdd || isGitRestoreStaged) {
         const rawPaths =
           command
-            .replace(/^git\s+add\s+/i, '')
+            .replace(
+              isGitAdd
+                ? /^git\s+add\s+/i
+                : /^git\s+restore\s+--staged\s+/i,
+              '',
+            )
             .match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []
         const stagedPaths = rawPaths
           .map((value) =>
@@ -1653,7 +1880,7 @@ export function evaluateTerminalCommandPolicy(params: {
           return {
             allowed: false,
             reason:
-              'git add paths must be an exact subset of the spawn-bound owned_paths allowlist',
+              'git add and git restore --staged paths must be an exact subset of the spawn-bound owned_paths allowlist',
           }
         }
       }
@@ -1803,7 +2030,13 @@ export function evaluateTerminalCommandPolicy(params: {
         if (pattern.test(command)) return { allowed: false, reason }
       }
     }
-    const envIssue = findProcessEnvironmentIssueInCommand(command, 'workspace')
+    const envIssue = findProcessEnvironmentIssueInCommand(
+      command,
+      'workspace',
+      params.permissionProfile === 'workspace-write'
+        ? 'inspect-bodies'
+        : 'fail-closed',
+    )
     if (envIssue) return { allowed: false, reason: envIssue }
     const outsidePath = findOutsideAbsolutePath(command, params.projectRoot)
     if (outsidePath) {


### PR DESCRIPTION
Allow in-project cd, everyday bash control flow, inspected substitutions, and gh pr under workspace-write while keeping env-dump, traversal, and privilege guards. Also allow git restore --staged -- pathspecs and apply allowedPaths to staged restore under git-commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/58)
<!-- Reviewable:end -->
