### PR TITLE
refactor(sdk): shared bounded-readdir helper and streamDirectory adapter docs

### DIFF
--- a/common/src/__tests__/project-file-tree-max-files.test.ts
+++ b/common/src/__tests__/project-file-tree-max-files.test.ts
@@ -1,0 +1,115 @@
+import path from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import { flattenTree, getProjectFileTree } from '../project-file-tree'
+
+import type { CodebuffFileSystem } from '../types/filesystem'
+
+const PROJECT_ROOT = '/synthetic-project-root'
+const SUBDIRS = ['dir-a', 'dir-b', 'dir-c']
+const FILES_PER_SUBDIR = 5000
+const MAX_FILES = 50
+
+/**
+ * Builds a fully in-memory fs stub for a synthetic adversarial tree:
+ *
+ *   /synthetic-project-root
+ *   ├── dir-a/  (5000 files)
+ *   ├── dir-b/  (5000 files)
+ *   └── dir-c/  (5000 files)
+ *
+ * `readdir` records every directory it is asked about so tests can prove
+ * enumeration stops early instead of draining the whole tree. `stat` always
+ * succeeds (throwing stats are swallowed by getProjectFileTree, which would
+ * silently skew the counts), and ignore files resolve to empty content so
+ * parseGitignore never hits real I/O or errors.
+ */
+function makeAdversarialFs() {
+  const readdirCalls: string[] = []
+
+  const fs = {
+    readdir: async (dirPath: string): Promise<string[]> => {
+      readdirCalls.push(dirPath)
+      const relativeDir = path.relative(PROJECT_ROOT, dirPath)
+      if (relativeDir === '') {
+        return [...SUBDIRS]
+      }
+      if (SUBDIRS.includes(relativeDir)) {
+        return Array.from(
+          { length: FILES_PER_SUBDIR },
+          (_, index) => `file-${String(index).padStart(4, '0')}.txt`,
+        )
+      }
+      return []
+    },
+    stat: async (filePath: string) => {
+      const relativePath = path.relative(PROJECT_ROOT, filePath)
+      const isDirectory = SUBDIRS.includes(relativePath)
+      return {
+        isDirectory: () => isDirectory,
+        isFile: () => !isDirectory,
+        atimeMs: 0,
+        mtimeMs: 0,
+        ctimeMs: 0,
+        birthtimeMs: 0,
+        size: isDirectory ? 0 : 1,
+      }
+    },
+    readFile: async (filePath: string): Promise<string> => {
+      if (
+        filePath.endsWith('.gitignore') ||
+        filePath.endsWith('.openbuffignore')
+      ) {
+        return ''
+      }
+      throw Object.assign(new Error(`ENOENT: no such file: ${filePath}`), {
+        code: 'ENOENT',
+      })
+    },
+  } as unknown as CodebuffFileSystem
+
+  return { fs, readdirCalls }
+}
+
+async function runScenario() {
+  const { fs, readdirCalls } = makeAdversarialFs()
+  const tree = await getProjectFileTree({
+    projectRoot: PROJECT_ROOT,
+    maxFiles: MAX_FILES,
+    fs,
+  })
+  return { tree, readdirCalls }
+}
+
+describe('getProjectFileTree maxFiles cap', () => {
+  test('stops enumerating once maxFiles files are collected instead of draining the tree', async () => {
+    const { tree, readdirCalls } = await runScenario()
+
+    const files = flattenTree(tree).filter((node) => node.type === 'file')
+    expect(files).toHaveLength(MAX_FILES)
+
+    // Only the root and the first subdir may be enumerated: the cap must fire
+    // inside dir-a's entry loop, and the BFS while-condition must stop the
+    // walk before dir-b/dir-c are ever readdir'd (15000 entries exist).
+    expect(readdirCalls.length).toBeLessThanOrEqual(2)
+    expect(readdirCalls).not.toContain(path.join(PROJECT_ROOT, 'dir-b'))
+    expect(readdirCalls).not.toContain(path.join(PROJECT_ROOT, 'dir-c'))
+  })
+
+  test('yields a stable file count across repeated calls', async () => {
+    const first = await runScenario()
+    const second = await runScenario()
+
+    const firstCount = flattenTree(first.tree).filter(
+      (node) => node.type === 'file',
+    ).length
+    const secondCount = flattenTree(second.tree).filter(
+      (node) => node.type === 'file',
+    ).length
+
+    expect(firstCount).toBe(MAX_FILES)
+    expect(secondCount).toBe(firstCount)
+    expect(second.readdirCalls.length).toBe(first.readdirCalls.length)
+  })
+})

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -63,6 +63,39 @@ Custom adapters should implement the optional capabilities they can guarantee:
 - `conditionalDelete` guards deletions with an exact-byte expected hash.
 - `conditionalMove` requires the source hash and an absent destination.
 
+Declare `streamDirectory` only when you can guarantee both obligations above:
+the iterator releases its handle from `return()`, and `readdirView` is the
+adapter's current `readdir`. A mis-paired `readdirView` silently disables the
+capability — callers fall back to full `readdir` materialization with no
+diagnostic. Confirm the finished wiring with `supportsStreamDirectory()`, not
+by checking member presence:
+
+```ts
+import type fs from 'fs'
+import type { Dirent } from 'fs'
+import { supportsStreamDirectory } from '@openbuff/sdk'
+import type { CodebuffFileSystem } from '@openbuff/sdk'
+
+// Virtual directory store: path -> entries. Both views below serve this store.
+const directories = new Map<string, Dirent[]>()
+
+// The adapter's own `readdir` (a real one carries the full fs.promises
+// overload set, elided here).
+const readdir = (path: fs.PathLike): Promise<Dirent[]> =>
+  Promise.resolve(directories.get(String(path)) ?? [])
+
+// Breaking out of `for await` calls the generator's built-in `return()`, releasing the handle.
+async function* iterate(path: fs.PathLike): AsyncGenerator<Dirent> {
+  yield* directories.get(String(path)) ?? []
+}
+
+const streamDirectory: NonNullable<CodebuffFileSystem['streamDirectory']> =
+  Object.assign((path: fs.PathLike) => iterate(path), { readdirView: readdir })
+
+const adapter = { readdir, streamDirectory }
+console.log(supportsStreamDirectory(adapter)) // true
+```
+
 Tools that require a host process, such as terminal commands and configured
 validation hooks, are separate from the filesystem adapter. Virtual or remote
 hosts should override or disable process-backed tools when the local process

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -35,18 +35,17 @@ export {
   hashFileContent,
 } from './tools/filesystem-authority'
 // Capability detection for the optional `streamDirectory` capability. Kept with
-// the consumer of the capability so the published predicate and the listing
-// behaviour cannot diverge; presence of the member alone is not sufficient,
-// since the `readdirView` pairing is part of the contract.
+// the shared bounded directory read that consumes the capability so the
+// published predicate and the listing behaviour cannot diverge; presence of
+// the member alone is not sufficient, since the `readdirView` pairing is part
+// of the contract.
 //
 // `MAX_LIST_DIRECTORY_ENTRIES` is published alongside it because the bounded
 // listing no longer reports the observed entry count: it is the supported way
 // for consumers to obtain the cap instead of parsing it out of the
 // `list_directory` error message.
-export {
-  MAX_LIST_DIRECTORY_ENTRIES,
-  supportsStreamDirectory,
-} from './tools/list-directory'
+export { MAX_LIST_DIRECTORY_ENTRIES } from './tools/list-directory'
+export { supportsStreamDirectory } from './tools/bounded-readdir'
 export type { FileFilter, FileFilterResult } from './tools/read-files'
 export type {
   FilesystemError,

--- a/sdk/src/tools/bounded-readdir.ts
+++ b/sdk/src/tools/bounded-readdir.ts
@@ -1,0 +1,64 @@
+// Shared bounded/streaming directory read for SDK tools.
+
+import { MAX_LIST_DIRECTORY_ENTRIES } from '@codebuff/common/tools/params/tool/list-directory'
+
+import type {
+  CodebuffFileSystem,
+  CodebuffStreamDirectory,
+} from '@codebuff/common/types/filesystem'
+import type { Dirent } from 'fs'
+
+/**
+ * The streaming capability when it is usable, otherwise `undefined`. Usable
+ * means callable AND paired with this adapter's current `readdir`: a decorating
+ * adapter copies `streamDirectory` over as an own property while overriding
+ * `readdir`, so the pairing is what keeps the listing on the adapter's own
+ * view. Mis-wiring guard, not a trust boundary: see `CodebuffStreamDirectory`.
+ */
+export function resolveStreamDirectory(
+  fs: CodebuffFileSystem,
+): CodebuffStreamDirectory | undefined {
+  const streamDirectory = fs.streamDirectory
+  return typeof streamDirectory === 'function' &&
+    streamDirectory.readdirView === fs.readdir
+    ? streamDirectory
+    : undefined
+}
+
+/**
+ * Whether `fs` provides usable streaming directory iteration, i.e. whether
+ * `list_directory` takes the bounded streaming path for this adapter.
+ *
+ * Published as the capability-detection entry point for `streamDirectory`
+ * because presence of the member is only half the condition:
+ * `detectFilesystemCapabilities` reports members, and cannot express the
+ * `readdirView` pairing. Consumers asking "does this adapter stream?" must use
+ * this so their answer cannot drift from the decision the tool actually makes.
+ */
+export function supportsStreamDirectory(fs: CodebuffFileSystem): boolean {
+  return resolveStreamDirectory(fs) !== undefined
+}
+
+/**
+ * Read at most `MAX_LIST_DIRECTORY_ENTRIES + 1` entries: one past the cap makes
+ * "over the cap" decidable without counting the whole directory. See
+ * `CodebuffStreamDirectory` in common for the streaming contract this relies on.
+ */
+export async function readBoundedEntries(
+  fs: CodebuffFileSystem,
+  directoryPath: string,
+): Promise<Dirent[]> {
+  const limit = MAX_LIST_DIRECTORY_ENTRIES + 1
+  const streamDirectory = resolveStreamDirectory(fs)
+  if (!streamDirectory) {
+    const entries = await fs.readdir(directoryPath, { withFileTypes: true })
+    return entries.slice(0, limit)
+  }
+
+  const entries: Dirent[] = []
+  for await (const entry of await streamDirectory.call(fs, directoryPath)) {
+    entries.push(entry)
+    if (entries.length === limit) break
+  }
+  return entries
+}

--- a/sdk/src/tools/list-directory.ts
+++ b/sdk/src/tools/list-directory.ts
@@ -2,74 +2,18 @@ import * as path from 'path'
 
 import { MAX_LIST_DIRECTORY_ENTRIES } from '@codebuff/common/tools/params/tool/list-directory'
 
+import { readBoundedEntries } from './bounded-readdir'
 import { resolveFilePathForFileSystemOperation } from './path-utils'
 import { isReadPathBlocked } from './read-policy'
 
 import type { CodebuffToolOutput } from '@codebuff/common/tools/list'
-import type {
-  CodebuffFileSystem,
-  CodebuffStreamDirectory,
-} from '@codebuff/common/types/filesystem'
-import type { Dirent } from 'fs'
+import type { CodebuffFileSystem } from '@codebuff/common/types/filesystem'
 import type { FileFilter } from './read-files'
 
 /** Defined in common so the tool description states the same number. */
 export { MAX_LIST_DIRECTORY_ENTRIES }
 
-/**
- * The streaming capability when it is usable, otherwise `undefined`. Usable
- * means callable AND paired with this adapter's current `readdir`: a decorating
- * adapter copies `streamDirectory` over as an own property while overriding
- * `readdir`, so the pairing is what keeps the listing on the adapter's own
- * view. Mis-wiring guard, not a trust boundary: see `CodebuffStreamDirectory`.
- */
-function resolveStreamDirectory(
-  fs: CodebuffFileSystem,
-): CodebuffStreamDirectory | undefined {
-  const streamDirectory = fs.streamDirectory
-  return typeof streamDirectory === 'function' &&
-    streamDirectory.readdirView === fs.readdir
-    ? streamDirectory
-    : undefined
-}
-
-/**
- * Whether `fs` provides usable streaming directory iteration, i.e. whether
- * `list_directory` takes the bounded streaming path for this adapter.
- *
- * Published as the capability-detection entry point for `streamDirectory`
- * because presence of the member is only half the condition:
- * `detectFilesystemCapabilities` reports members, and cannot express the
- * `readdirView` pairing. Consumers asking "does this adapter stream?" must use
- * this so their answer cannot drift from the decision the tool actually makes.
- */
-export function supportsStreamDirectory(fs: CodebuffFileSystem): boolean {
-  return resolveStreamDirectory(fs) !== undefined
-}
-
-/**
- * Read at most `MAX_LIST_DIRECTORY_ENTRIES + 1` entries: one past the cap makes
- * "over the cap" decidable without counting the whole directory. See
- * `CodebuffStreamDirectory` in common for the streaming contract this relies on.
- */
-async function readBoundedEntries(
-  fs: CodebuffFileSystem,
-  directoryPath: string,
-): Promise<Dirent[]> {
-  const limit = MAX_LIST_DIRECTORY_ENTRIES + 1
-  const streamDirectory = resolveStreamDirectory(fs)
-  if (!streamDirectory) {
-    const entries = await fs.readdir(directoryPath, { withFileTypes: true })
-    return entries.slice(0, limit)
-  }
-
-  const entries: Dirent[] = []
-  for await (const entry of await streamDirectory.call(fs, directoryPath)) {
-    entries.push(entry)
-    if (entries.length === limit) break
-  }
-  return entries
-}
+export { supportsStreamDirectory } from './bounded-readdir'
 
 export async function listDirectory(params: {
   directoryPath: string


### PR DESCRIPTION
Follow-up delivery to PR 61, which merged at e20abd61a before these two commits landed.

- docs(sdk) commit 403e2c3f7: runnable virtual-adapter example in the sdk README showing how to implement the optional streamDirectory capability correctly: Map-backed store, async-generator iteration that releases the handle when iteration stops early, readdirView paired with the adapter own readdir via Object.assign, verified with the published supportsStreamDirectory predicate.
- refactor(sdk) commit bf5a8b68a: extract resolveStreamDirectory, supportsStreamDirectory, and readBoundedEntries verbatim into shared sdk tools bounded-readdir module; list-directory keeps a one-line re-export so existing import paths pass unchanged; sdk index repoints the published predicate to the defining module. Adds a deterministic common test proving getProjectFileTree stops enumerating at maxFiles instead of draining the tree.

Validation: repo typecheck exit 0 across all 11 packages; sdk suite 1028 passed 0 failed across 72 files; new regression test 2 passed 0 failed; automated reviewer gate LOOKS_GOOD with zero findings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AnzoBenjamin/openbuff/62)
<!-- Reviewable:end -->
